### PR TITLE
fix: 待機画面のキャリブレーションUIと鬼指名の取り消しを改善

### DIFF
--- a/docs/rtdb-schema.md
+++ b/docs/rtdb-schema.md
@@ -32,6 +32,7 @@ rooms/
         displayName
         role              "FUGITIVE" | "DEMON"
         pressureOffset
+        pressureSensorAvailable  気圧センサーの有無(true/false)。判定前は未設定
         becameDemonAt
         lastPhotoAt
         joinedAt

--- a/lib/features/pressure/repository/pressure_repository.dart
+++ b/lib/features/pressure/repository/pressure_repository.dart
@@ -84,6 +84,23 @@ class PressureRepository {
     _latestSmoothed = null;
   }
 
+  /// 気圧センサーの有無を、ホスト・参加者を把握できるようRTDBに記録する。
+  /// 未搭載の端末はキャリブレーション不要であることを他の参加者にも
+  /// 伝えるための情報で、必須では無いため失敗しても無視してよい。
+  Future<void> reportSensorAvailability(
+    String roomId, {
+    required bool available,
+  }) async {
+    try {
+      await _db
+          .ref('rooms/$roomId/users/$_uid/pressureSensorAvailable')
+          .set(available);
+    } on Object {
+      // 待機画面の表示が多少不正確になるだけで、キャリブレーション自体は
+      // 可能なため致命的ではない。
+    }
+  }
+
   /// ホストが自分の気圧を基準値として書き込む。
   Future<void> calibrateAsHost(String roomId, double myPressureHPa) async {
     await _db.ref('rooms/$roomId/meta/basePressure').set(myPressureHPa);

--- a/lib/features/pressure/view_model/pressure_view_model.dart
+++ b/lib/features/pressure/view_model/pressure_view_model.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -31,11 +33,13 @@ class PressureViewModel extends Notifier<PressureState> {
   PressureRepository get _repo => ref.read(pressureRepositoryProvider);
 
   /// 待機画面に入った時に呼ぶ。センサーの有無を確認し、使えるなら
-  /// 気圧の購読を始める(何度呼んでも安全)。
-  Future<void> init() async {
+  /// 気圧の購読を始める(何度呼んでも安全)。判定結果は他の参加者にも
+  /// 伝わるようroomIdのRTDBへ記録する(待機画面の一覧・集計表示用)。
+  Future<void> init(String roomId) async {
     if (state.sensorAvailability == PressureSensorAvailability.available) return;
 
     final available = await _repo.checkSensorAvailable();
+    unawaited(_repo.reportSensorAvailability(roomId, available: available));
     if (!available) {
       state = state.copyWith(sensorAvailability: PressureSensorAvailability.unavailable);
       return;

--- a/lib/features/room/calibration_status.dart
+++ b/lib/features/room/calibration_status.dart
@@ -1,0 +1,35 @@
+/// 参加者1人分の気圧センサーキャリブレーション状況。
+enum CalibrationStatus {
+  /// この端末は気圧センサー非搭載で、キャリブレーション自体が不要。
+  unavailable,
+
+  /// センサーはあるが、まだキャリブレーションを済ませていない。
+  pending,
+
+  /// キャリブレーション済み。
+  done,
+}
+
+/// 1人分のキャリブレーション状況を判定する。
+///
+/// ホストは`room.basePressure`、参加者は`user.pressureOffset`の有無で
+/// 完了を判定する(書き込み先のパスが役割によって異なるため)。
+/// `sensorAvailable`が明示的にfalseの場合のみ非対応扱いにし、
+/// 未確定(null、判定中)の場合は完了扱いにならない限りpendingとする。
+CalibrationStatus calibrationStatusFor({
+  required bool isHost,
+  required bool? sensorAvailable,
+  required double? basePressure,
+  required double? pressureOffset,
+}) {
+  final done = isHost ? basePressure != null : pressureOffset != null;
+  if (done) return CalibrationStatus.done;
+  if (sensorAvailable == false) return CalibrationStatus.unavailable;
+  return CalibrationStatus.pending;
+}
+
+/// センサー搭載者(unavailable以外)全員が完了しているかどうか。
+/// センサー搭載者が1人もいなければ(全員unavailableなら)真を返す。
+bool isCalibrationComplete(Iterable<CalibrationStatus> statuses) {
+  return statuses.every((status) => status != CalibrationStatus.pending);
+}

--- a/lib/features/room/model/room_user.dart
+++ b/lib/features/room/model/room_user.dart
@@ -20,6 +20,7 @@ abstract class RoomUser with _$RoomUser {
     @Default(false) bool isHost,
     @Default(UserRole.fugitive) @JsonKey(unknownEnumValue: UserRole.fugitive) UserRole role,
     double? pressureOffset,
+    bool? pressureSensorAvailable,
     int? becameDemonAt,
     int? lastPhotoAt,
     @Default(0) int joinedAt,

--- a/lib/features/room/model/room_user.freezed.dart
+++ b/lib/features/room/model/room_user.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RoomUser {
 
- String get id; String get displayName; String get deviceId; bool get isHost;@JsonKey(unknownEnumValue: UserRole.fugitive) UserRole get role; double? get pressureOffset; int? get becameDemonAt; int? get lastPhotoAt; int get joinedAt;
+ String get id; String get displayName; String get deviceId; bool get isHost;@JsonKey(unknownEnumValue: UserRole.fugitive) UserRole get role; double? get pressureOffset; bool? get pressureSensorAvailable; int? get becameDemonAt; int? get lastPhotoAt; int get joinedAt;
 /// Create a copy of RoomUser
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $RoomUserCopyWith<RoomUser> get copyWith => _$RoomUserCopyWithImpl<RoomUser>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RoomUser&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.deviceId, deviceId) || other.deviceId == deviceId)&&(identical(other.isHost, isHost) || other.isHost == isHost)&&(identical(other.role, role) || other.role == role)&&(identical(other.pressureOffset, pressureOffset) || other.pressureOffset == pressureOffset)&&(identical(other.becameDemonAt, becameDemonAt) || other.becameDemonAt == becameDemonAt)&&(identical(other.lastPhotoAt, lastPhotoAt) || other.lastPhotoAt == lastPhotoAt)&&(identical(other.joinedAt, joinedAt) || other.joinedAt == joinedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RoomUser&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.deviceId, deviceId) || other.deviceId == deviceId)&&(identical(other.isHost, isHost) || other.isHost == isHost)&&(identical(other.role, role) || other.role == role)&&(identical(other.pressureOffset, pressureOffset) || other.pressureOffset == pressureOffset)&&(identical(other.pressureSensorAvailable, pressureSensorAvailable) || other.pressureSensorAvailable == pressureSensorAvailable)&&(identical(other.becameDemonAt, becameDemonAt) || other.becameDemonAt == becameDemonAt)&&(identical(other.lastPhotoAt, lastPhotoAt) || other.lastPhotoAt == lastPhotoAt)&&(identical(other.joinedAt, joinedAt) || other.joinedAt == joinedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,displayName,deviceId,isHost,role,pressureOffset,becameDemonAt,lastPhotoAt,joinedAt);
+int get hashCode => Object.hash(runtimeType,id,displayName,deviceId,isHost,role,pressureOffset,pressureSensorAvailable,becameDemonAt,lastPhotoAt,joinedAt);
 
 @override
 String toString() {
-  return 'RoomUser(id: $id, displayName: $displayName, deviceId: $deviceId, isHost: $isHost, role: $role, pressureOffset: $pressureOffset, becameDemonAt: $becameDemonAt, lastPhotoAt: $lastPhotoAt, joinedAt: $joinedAt)';
+  return 'RoomUser(id: $id, displayName: $displayName, deviceId: $deviceId, isHost: $isHost, role: $role, pressureOffset: $pressureOffset, pressureSensorAvailable: $pressureSensorAvailable, becameDemonAt: $becameDemonAt, lastPhotoAt: $lastPhotoAt, joinedAt: $joinedAt)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $RoomUserCopyWith<$Res>  {
   factory $RoomUserCopyWith(RoomUser value, $Res Function(RoomUser) _then) = _$RoomUserCopyWithImpl;
 @useResult
 $Res call({
- String id, String displayName, String deviceId, bool isHost,@JsonKey(unknownEnumValue: UserRole.fugitive) UserRole role, double? pressureOffset, int? becameDemonAt, int? lastPhotoAt, int joinedAt
+ String id, String displayName, String deviceId, bool isHost,@JsonKey(unknownEnumValue: UserRole.fugitive) UserRole role, double? pressureOffset, bool? pressureSensorAvailable, int? becameDemonAt, int? lastPhotoAt, int joinedAt
 });
 
 
@@ -65,7 +65,7 @@ class _$RoomUserCopyWithImpl<$Res>
 
 /// Create a copy of RoomUser
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? displayName = null,Object? deviceId = null,Object? isHost = null,Object? role = null,Object? pressureOffset = freezed,Object? becameDemonAt = freezed,Object? lastPhotoAt = freezed,Object? joinedAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? displayName = null,Object? deviceId = null,Object? isHost = null,Object? role = null,Object? pressureOffset = freezed,Object? pressureSensorAvailable = freezed,Object? becameDemonAt = freezed,Object? lastPhotoAt = freezed,Object? joinedAt = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,displayName: null == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
@@ -73,7 +73,8 @@ as String,deviceId: null == deviceId ? _self.deviceId : deviceId // ignore: cast
 as String,isHost: null == isHost ? _self.isHost : isHost // ignore: cast_nullable_to_non_nullable
 as bool,role: null == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
 as UserRole,pressureOffset: freezed == pressureOffset ? _self.pressureOffset : pressureOffset // ignore: cast_nullable_to_non_nullable
-as double?,becameDemonAt: freezed == becameDemonAt ? _self.becameDemonAt : becameDemonAt // ignore: cast_nullable_to_non_nullable
+as double?,pressureSensorAvailable: freezed == pressureSensorAvailable ? _self.pressureSensorAvailable : pressureSensorAvailable // ignore: cast_nullable_to_non_nullable
+as bool?,becameDemonAt: freezed == becameDemonAt ? _self.becameDemonAt : becameDemonAt // ignore: cast_nullable_to_non_nullable
 as int?,lastPhotoAt: freezed == lastPhotoAt ? _self.lastPhotoAt : lastPhotoAt // ignore: cast_nullable_to_non_nullable
 as int?,joinedAt: null == joinedAt ? _self.joinedAt : joinedAt // ignore: cast_nullable_to_non_nullable
 as int,
@@ -161,10 +162,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String displayName,  String deviceId,  bool isHost, @JsonKey(unknownEnumValue: UserRole.fugitive)  UserRole role,  double? pressureOffset,  int? becameDemonAt,  int? lastPhotoAt,  int joinedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String displayName,  String deviceId,  bool isHost, @JsonKey(unknownEnumValue: UserRole.fugitive)  UserRole role,  double? pressureOffset,  bool? pressureSensorAvailable,  int? becameDemonAt,  int? lastPhotoAt,  int joinedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _RoomUser() when $default != null:
-return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.role,_that.pressureOffset,_that.becameDemonAt,_that.lastPhotoAt,_that.joinedAt);case _:
+return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.role,_that.pressureOffset,_that.pressureSensorAvailable,_that.becameDemonAt,_that.lastPhotoAt,_that.joinedAt);case _:
   return orElse();
 
 }
@@ -182,10 +183,10 @@ return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.rol
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String displayName,  String deviceId,  bool isHost, @JsonKey(unknownEnumValue: UserRole.fugitive)  UserRole role,  double? pressureOffset,  int? becameDemonAt,  int? lastPhotoAt,  int joinedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String displayName,  String deviceId,  bool isHost, @JsonKey(unknownEnumValue: UserRole.fugitive)  UserRole role,  double? pressureOffset,  bool? pressureSensorAvailable,  int? becameDemonAt,  int? lastPhotoAt,  int joinedAt)  $default,) {final _that = this;
 switch (_that) {
 case _RoomUser():
-return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.role,_that.pressureOffset,_that.becameDemonAt,_that.lastPhotoAt,_that.joinedAt);case _:
+return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.role,_that.pressureOffset,_that.pressureSensorAvailable,_that.becameDemonAt,_that.lastPhotoAt,_that.joinedAt);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -202,10 +203,10 @@ return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.rol
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String displayName,  String deviceId,  bool isHost, @JsonKey(unknownEnumValue: UserRole.fugitive)  UserRole role,  double? pressureOffset,  int? becameDemonAt,  int? lastPhotoAt,  int joinedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String displayName,  String deviceId,  bool isHost, @JsonKey(unknownEnumValue: UserRole.fugitive)  UserRole role,  double? pressureOffset,  bool? pressureSensorAvailable,  int? becameDemonAt,  int? lastPhotoAt,  int joinedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _RoomUser() when $default != null:
-return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.role,_that.pressureOffset,_that.becameDemonAt,_that.lastPhotoAt,_that.joinedAt);case _:
+return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.role,_that.pressureOffset,_that.pressureSensorAvailable,_that.becameDemonAt,_that.lastPhotoAt,_that.joinedAt);case _:
   return null;
 
 }
@@ -217,7 +218,7 @@ return $default(_that.id,_that.displayName,_that.deviceId,_that.isHost,_that.rol
 @JsonSerializable()
 
 class _RoomUser extends RoomUser {
-  const _RoomUser({required this.id, this.displayName = '', this.deviceId = '', this.isHost = false, @JsonKey(unknownEnumValue: UserRole.fugitive) this.role = UserRole.fugitive, this.pressureOffset, this.becameDemonAt, this.lastPhotoAt, this.joinedAt = 0}): super._();
+  const _RoomUser({required this.id, this.displayName = '', this.deviceId = '', this.isHost = false, @JsonKey(unknownEnumValue: UserRole.fugitive) this.role = UserRole.fugitive, this.pressureOffset, this.pressureSensorAvailable, this.becameDemonAt, this.lastPhotoAt, this.joinedAt = 0}): super._();
   factory _RoomUser.fromJson(Map<String, dynamic> json) => _$RoomUserFromJson(json);
 
 @override final  String id;
@@ -226,6 +227,7 @@ class _RoomUser extends RoomUser {
 @override@JsonKey() final  bool isHost;
 @override@JsonKey(unknownEnumValue: UserRole.fugitive) final  UserRole role;
 @override final  double? pressureOffset;
+@override final  bool? pressureSensorAvailable;
 @override final  int? becameDemonAt;
 @override final  int? lastPhotoAt;
 @override@JsonKey() final  int joinedAt;
@@ -243,16 +245,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RoomUser&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.deviceId, deviceId) || other.deviceId == deviceId)&&(identical(other.isHost, isHost) || other.isHost == isHost)&&(identical(other.role, role) || other.role == role)&&(identical(other.pressureOffset, pressureOffset) || other.pressureOffset == pressureOffset)&&(identical(other.becameDemonAt, becameDemonAt) || other.becameDemonAt == becameDemonAt)&&(identical(other.lastPhotoAt, lastPhotoAt) || other.lastPhotoAt == lastPhotoAt)&&(identical(other.joinedAt, joinedAt) || other.joinedAt == joinedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RoomUser&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.deviceId, deviceId) || other.deviceId == deviceId)&&(identical(other.isHost, isHost) || other.isHost == isHost)&&(identical(other.role, role) || other.role == role)&&(identical(other.pressureOffset, pressureOffset) || other.pressureOffset == pressureOffset)&&(identical(other.pressureSensorAvailable, pressureSensorAvailable) || other.pressureSensorAvailable == pressureSensorAvailable)&&(identical(other.becameDemonAt, becameDemonAt) || other.becameDemonAt == becameDemonAt)&&(identical(other.lastPhotoAt, lastPhotoAt) || other.lastPhotoAt == lastPhotoAt)&&(identical(other.joinedAt, joinedAt) || other.joinedAt == joinedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,displayName,deviceId,isHost,role,pressureOffset,becameDemonAt,lastPhotoAt,joinedAt);
+int get hashCode => Object.hash(runtimeType,id,displayName,deviceId,isHost,role,pressureOffset,pressureSensorAvailable,becameDemonAt,lastPhotoAt,joinedAt);
 
 @override
 String toString() {
-  return 'RoomUser(id: $id, displayName: $displayName, deviceId: $deviceId, isHost: $isHost, role: $role, pressureOffset: $pressureOffset, becameDemonAt: $becameDemonAt, lastPhotoAt: $lastPhotoAt, joinedAt: $joinedAt)';
+  return 'RoomUser(id: $id, displayName: $displayName, deviceId: $deviceId, isHost: $isHost, role: $role, pressureOffset: $pressureOffset, pressureSensorAvailable: $pressureSensorAvailable, becameDemonAt: $becameDemonAt, lastPhotoAt: $lastPhotoAt, joinedAt: $joinedAt)';
 }
 
 
@@ -263,7 +265,7 @@ abstract mixin class _$RoomUserCopyWith<$Res> implements $RoomUserCopyWith<$Res>
   factory _$RoomUserCopyWith(_RoomUser value, $Res Function(_RoomUser) _then) = __$RoomUserCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String displayName, String deviceId, bool isHost,@JsonKey(unknownEnumValue: UserRole.fugitive) UserRole role, double? pressureOffset, int? becameDemonAt, int? lastPhotoAt, int joinedAt
+ String id, String displayName, String deviceId, bool isHost,@JsonKey(unknownEnumValue: UserRole.fugitive) UserRole role, double? pressureOffset, bool? pressureSensorAvailable, int? becameDemonAt, int? lastPhotoAt, int joinedAt
 });
 
 
@@ -280,7 +282,7 @@ class __$RoomUserCopyWithImpl<$Res>
 
 /// Create a copy of RoomUser
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? displayName = null,Object? deviceId = null,Object? isHost = null,Object? role = null,Object? pressureOffset = freezed,Object? becameDemonAt = freezed,Object? lastPhotoAt = freezed,Object? joinedAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? displayName = null,Object? deviceId = null,Object? isHost = null,Object? role = null,Object? pressureOffset = freezed,Object? pressureSensorAvailable = freezed,Object? becameDemonAt = freezed,Object? lastPhotoAt = freezed,Object? joinedAt = null,}) {
   return _then(_RoomUser(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,displayName: null == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
@@ -288,7 +290,8 @@ as String,deviceId: null == deviceId ? _self.deviceId : deviceId // ignore: cast
 as String,isHost: null == isHost ? _self.isHost : isHost // ignore: cast_nullable_to_non_nullable
 as bool,role: null == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
 as UserRole,pressureOffset: freezed == pressureOffset ? _self.pressureOffset : pressureOffset // ignore: cast_nullable_to_non_nullable
-as double?,becameDemonAt: freezed == becameDemonAt ? _self.becameDemonAt : becameDemonAt // ignore: cast_nullable_to_non_nullable
+as double?,pressureSensorAvailable: freezed == pressureSensorAvailable ? _self.pressureSensorAvailable : pressureSensorAvailable // ignore: cast_nullable_to_non_nullable
+as bool?,becameDemonAt: freezed == becameDemonAt ? _self.becameDemonAt : becameDemonAt // ignore: cast_nullable_to_non_nullable
 as int?,lastPhotoAt: freezed == lastPhotoAt ? _self.lastPhotoAt : lastPhotoAt // ignore: cast_nullable_to_non_nullable
 as int?,joinedAt: null == joinedAt ? _self.joinedAt : joinedAt // ignore: cast_nullable_to_non_nullable
 as int,

--- a/lib/features/room/model/room_user.g.dart
+++ b/lib/features/room/model/room_user.g.dart
@@ -19,6 +19,7 @@ _RoomUser _$RoomUserFromJson(Map<String, dynamic> json) => _RoomUser(
       ) ??
       UserRole.fugitive,
   pressureOffset: (json['pressureOffset'] as num?)?.toDouble(),
+  pressureSensorAvailable: json['pressureSensorAvailable'] as bool?,
   becameDemonAt: (json['becameDemonAt'] as num?)?.toInt(),
   lastPhotoAt: (json['lastPhotoAt'] as num?)?.toInt(),
   joinedAt: (json['joinedAt'] as num?)?.toInt() ?? 0,
@@ -31,6 +32,7 @@ Map<String, dynamic> _$RoomUserToJson(_RoomUser instance) => <String, dynamic>{
   'isHost': instance.isHost,
   'role': _$UserRoleEnumMap[instance.role]!,
   'pressureOffset': instance.pressureOffset,
+  'pressureSensorAvailable': instance.pressureSensorAvailable,
   'becameDemonAt': instance.becameDemonAt,
   'lastPhotoAt': instance.lastPhotoAt,
   'joinedAt': instance.joinedAt,

--- a/lib/features/room/repository/room_repository.dart
+++ b/lib/features/room/repository/room_repository.dart
@@ -143,6 +143,12 @@ class RoomRepository {
     await _db.ref('rooms/$roomId/meta/pendingDemonUid').set(uid);
   }
 
+  /// 指名を取り消す。対象者がまだ受諾(自己申告)していない間だけ意味を持つ
+  /// (対象者側が既に受諾済みならroleが変わっているため、これは無効化にしかならない)。
+  Future<void> cancelDemonNomination(String roomId) async {
+    await _db.ref('rooms/$roomId/meta/pendingDemonUid').set(null);
+  }
+
   /// 指名された本人が、指名を受諾して自分のroleをDEMONに更新する。
   Future<void> acceptDemonNomination(String roomId, String uid) async {
     await _db.ref('rooms/$roomId/users/$uid/role').set('DEMON');

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -89,7 +89,7 @@ class GamePage extends HookConsumerWidget {
     // 何度呼んでも安全)。
     useEffect(() {
       ref.read(pressureViewModelProvider.notifier)
-        ..init()
+        ..init(roomId)
         ..startSendingToRoom(roomId);
       return () => ref.read(pressureViewModelProvider.notifier).stopSendingAndDispose();
     }, [roomId]);

--- a/lib/features/room/view/room_waiting_page.dart
+++ b/lib/features/room/view/room_waiting_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kakureru/features/pressure/model/pressure_sensor_availability.dart';
 import 'package:kakureru/features/pressure/view_model/pressure_view_model.dart';
+import 'package:kakureru/features/room/calibration_status.dart';
 import 'package:kakureru/features/room/model/room.dart';
 import 'package:kakureru/features/room/model/room_user.dart';
 import 'package:kakureru/features/room/view/game_page.dart';
@@ -26,7 +27,7 @@ class RoomWaitingPage extends HookConsumerWidget {
     final myUid = FirebaseAuth.instance.currentUser?.uid;
 
     useEffect(() {
-      ref.read(pressureViewModelProvider.notifier).init();
+      ref.read(pressureViewModelProvider.notifier).init(roomId);
       return null;
     }, const []);
 
@@ -59,6 +60,28 @@ class RoomWaitingPage extends HookConsumerWidget {
           final hostCalibrated = room.basePressure != null;
           final demonCandidates = room.users.where((u) => u.role != UserRole.demon).toList();
 
+          final calibrationStatuses = {
+            for (final u in room.users)
+              u.id: calibrationStatusFor(
+                isHost: u.id == room.hostUserId,
+                sensorAvailable: u.pressureSensorAvailable,
+                basePressure: room.basePressure,
+                pressureOffset: u.pressureOffset,
+              ),
+          };
+          final requiredCount = calibrationStatuses.values
+              .where((s) => s != CalibrationStatus.unavailable)
+              .length;
+          final doneCount = calibrationStatuses.values
+              .where((s) => s == CalibrationStatus.done)
+              .length;
+          final allCalibrated = isCalibrationComplete(calibrationStatuses.values);
+          final pendingNames = room.users
+              .where((u) => calibrationStatuses[u.id] == CalibrationStatus.pending)
+              .map((u) => u.displayName)
+              .toList();
+          final myCalibrated = myUid != null && calibrationStatuses[myUid] == CalibrationStatus.done;
+
           return Column(
             children: [
               Padding(
@@ -79,13 +102,28 @@ class RoomWaitingPage extends HookConsumerWidget {
                     ).push(MaterialPageRoute(builder: (_) => RoomSettingPage(roomId: roomId))),
                   ),
                 ),
-              const Text('参加者'),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text('参加者'),
+                    if (requiredCount > 0)
+                      Text(
+                        'キャリブレーション $doneCount/$requiredCount人 完了',
+                        style: TextStyle(
+                          color: doneCount == requiredCount ? Colors.green : Colors.orange,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
               Expanded(
                 child: ListView(
                   children: room.users.map((u) {
-                    final calibrated = u.id == room.hostUserId
-                        ? hostCalibrated
-                        : u.pressureOffset != null;
+                    final status =
+                        calibrationStatuses[u.id] ?? CalibrationStatus.pending;
                     final isPending = room.pendingDemonUid == u.id && u.role != UserRole.demon;
 
                     return ListTile(
@@ -102,17 +140,25 @@ class RoomWaitingPage extends HookConsumerWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           if (u.isHost) const Padding(padding: EdgeInsets.only(right: 8), child: Text('ホスト')),
-                          Icon(
-                            calibrated ? Icons.check_circle : Icons.radio_button_unchecked,
-                            color: calibrated ? Colors.green : Colors.grey,
-                          ),
+                          _CalibrationStatusIcon(status: status),
                           if (isHost && u.role != UserRole.demon)
-                            IconButton(
-                              icon: const Icon(Icons.warning_amber),
-                              tooltip: '鬼にする',
-                              onPressed: room.pendingDemonUid != null
-                                  ? null
-                                  : () => ref.read(roomRepositoryProvider).nominateDemon(roomId, u.id),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 8),
+                              child: room.pendingDemonUid == u.id
+                                  ? ActionChip(
+                                      label: const Text('取り消す'),
+                                      onPressed: () => ref
+                                          .read(roomRepositoryProvider)
+                                          .cancelDemonNomination(roomId),
+                                    )
+                                  : ActionChip(
+                                      label: const Text('鬼にする'),
+                                      onPressed: room.pendingDemonUid != null
+                                          ? null
+                                          : () => ref
+                                                .read(roomRepositoryProvider)
+                                                .nominateDemon(roomId, u.id),
+                                    ),
                             ),
                         ],
                       ),
@@ -137,6 +183,7 @@ class RoomWaitingPage extends HookConsumerWidget {
                 roomId: roomId,
                 isHost: isHost,
                 hostCalibrated: hostCalibrated,
+                myCalibrated: myCalibrated,
                 basePressure: room.basePressure,
                 pressureState: pressureState,
               ),
@@ -148,11 +195,22 @@ class RoomWaitingPage extends HookConsumerWidget {
                     style: TextStyle(color: Colors.orange),
                   ),
                 ),
+              if (isHost && !allCalibrated && pendingNames.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Text(
+                    'キャリブレーション未完了: ${pendingNames.join('、')}',
+                    style: const TextStyle(color: Colors.orange),
+                  ),
+                ),
               if (isHost)
                 Padding(
                   padding: const EdgeInsets.all(24),
                   child: FilledButton(
-                    onPressed: isStarting.value || room.setting.gameArea.isEmpty
+                    onPressed:
+                        isStarting.value ||
+                            room.setting.gameArea.isEmpty ||
+                            !allCalibrated
                         ? null
                         : () async {
                             isStarting.value = true;
@@ -190,11 +248,36 @@ RoomUser? _findUser(List<RoomUser> users, String uid) {
   return null;
 }
 
+/// 参加者リストの行に出す、キャリブレーション状況アイコン。
+/// done(緑のチェック)/pending(グレーの未チェック)/unavailable(非対応)の
+/// 3状態を一目で区別できるようにする。
+class _CalibrationStatusIcon extends StatelessWidget {
+  const _CalibrationStatusIcon({required this.status});
+
+  final CalibrationStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (status) {
+      case CalibrationStatus.done:
+        return const Icon(Icons.check_circle, color: Colors.green);
+      case CalibrationStatus.pending:
+        return const Icon(Icons.radio_button_unchecked, color: Colors.orange);
+      case CalibrationStatus.unavailable:
+        return Tooltip(
+          message: '気圧センサー非対応',
+          child: Icon(Icons.sensors_off, color: Colors.grey.shade400),
+        );
+    }
+  }
+}
+
 class _CalibrationSection extends ConsumerWidget {
   const _CalibrationSection({
     required this.roomId,
     required this.isHost,
     required this.hostCalibrated,
+    required this.myCalibrated,
     required this.basePressure,
     required this.pressureState,
   });
@@ -202,15 +285,44 @@ class _CalibrationSection extends ConsumerWidget {
   final String roomId;
   final bool isHost;
   final bool hostCalibrated;
+  final bool myCalibrated;
   final double? basePressure;
   final PressureState pressureState;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      child: _buildMyStatus(ref),
+    );
+  }
+
+  Widget _buildMyStatus(WidgetRef ref) {
     if (pressureState.sensorAvailability == PressureSensorAvailability.unavailable) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-        child: Text('この端末は気圧センサー非対応です', style: TextStyle(color: Colors.orange)),
+      return const Row(
+        children: [
+          Icon(Icons.sensors_off, color: Colors.grey),
+          SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'この端末は気圧センサーに非対応です(キャリブレーション不要)',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (myCalibrated) {
+      return const Row(
+        children: [
+          Icon(Icons.check_circle, color: Colors.green),
+          SizedBox(width: 8),
+          Text(
+            'キャリブレーション完了',
+            style: TextStyle(color: Colors.green, fontWeight: FontWeight.bold),
+          ),
+        ],
       );
     }
 
@@ -227,26 +339,24 @@ class _CalibrationSection extends ConsumerWidget {
       hint = 'ホストのキャリブレーション待ち';
     }
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-      child: Column(
-        children: [
-          OutlinedButton(
-            onPressed: canCalibrate
-                ? () {
-                    final notifier = ref.read(pressureViewModelProvider.notifier);
-                    if (isHost) {
-                      notifier.calibrateAsHost(roomId);
-                    } else {
-                      notifier.calibrateAsParticipant(roomId, basePressure);
-                    }
+    return Column(
+      children: [
+        FilledButton.icon(
+          icon: const Icon(Icons.touch_app),
+          onPressed: canCalibrate
+              ? () {
+                  final notifier = ref.read(pressureViewModelProvider.notifier);
+                  if (isHost) {
+                    notifier.calibrateAsHost(roomId);
+                  } else {
+                    notifier.calibrateAsParticipant(roomId, basePressure);
                   }
-                : null,
-            child: const Text('キャリブレーション'),
-          ),
-          if (hint != null) Padding(padding: const EdgeInsets.only(top: 4), child: Text(hint)),
-        ],
-      ),
+                }
+              : null,
+          label: const Text('キャリブレーションする(未実施)'),
+        ),
+        if (hint != null) Padding(padding: const EdgeInsets.only(top: 4), child: Text(hint)),
+      ],
     );
   }
 }

--- a/test/features/room/calibration_status_test.dart
+++ b/test/features/room/calibration_status_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kakureru/features/room/calibration_status.dart';
+
+void main() {
+  group('calibrationStatusFor (host)', () {
+    test('basePressureが無ければpending', () {
+      expect(
+        calibrationStatusFor(
+          isHost: true,
+          sensorAvailable: true,
+          basePressure: null,
+          pressureOffset: null,
+        ),
+        CalibrationStatus.pending,
+      );
+    });
+
+    test('basePressureがあればdone', () {
+      expect(
+        calibrationStatusFor(
+          isHost: true,
+          sensorAvailable: true,
+          basePressure: 1013,
+          pressureOffset: null,
+        ),
+        CalibrationStatus.done,
+      );
+    });
+
+    test('センサー非搭載ならunavailable(未完了でも)', () {
+      expect(
+        calibrationStatusFor(
+          isHost: true,
+          sensorAvailable: false,
+          basePressure: null,
+          pressureOffset: null,
+        ),
+        CalibrationStatus.unavailable,
+      );
+    });
+  });
+
+  group('calibrationStatusFor (participant)', () {
+    test('pressureOffsetが無ければpending', () {
+      expect(
+        calibrationStatusFor(
+          isHost: false,
+          sensorAvailable: true,
+          basePressure: 1013,
+          pressureOffset: null,
+        ),
+        CalibrationStatus.pending,
+      );
+    });
+
+    test('pressureOffsetがあればdone', () {
+      expect(
+        calibrationStatusFor(
+          isHost: false,
+          sensorAvailable: true,
+          basePressure: 1013,
+          pressureOffset: -0.5,
+        ),
+        CalibrationStatus.done,
+      );
+    });
+
+    test('センサー非搭載ならunavailable', () {
+      expect(
+        calibrationStatusFor(
+          isHost: false,
+          sensorAvailable: false,
+          basePressure: 1013,
+          pressureOffset: null,
+        ),
+        CalibrationStatus.unavailable,
+      );
+    });
+
+    test('sensorAvailable未確定(null)でも未完了ならpending扱い', () {
+      expect(
+        calibrationStatusFor(
+          isHost: false,
+          sensorAvailable: null,
+          basePressure: 1013,
+          pressureOffset: null,
+        ),
+        CalibrationStatus.pending,
+      );
+    });
+
+    test('sensorAvailableがfalseでも既に完了していればdoneを優先する', () {
+      expect(
+        calibrationStatusFor(
+          isHost: false,
+          sensorAvailable: false,
+          basePressure: 1013,
+          pressureOffset: -0.5,
+        ),
+        CalibrationStatus.done,
+      );
+    });
+  });
+
+  group('isCalibrationComplete', () {
+    test('全員done/unavailableなら真', () {
+      expect(
+        isCalibrationComplete([
+          CalibrationStatus.done,
+          CalibrationStatus.unavailable,
+          CalibrationStatus.done,
+        ]),
+        isTrue,
+      );
+    });
+
+    test('1人でもpendingがいれば偽', () {
+      expect(
+        isCalibrationComplete([
+          CalibrationStatus.done,
+          CalibrationStatus.pending,
+        ]),
+        isFalse,
+      );
+    });
+
+    test('全員センサー非搭載(unavailableのみ)なら真', () {
+      expect(
+        isCalibrationComplete([
+          CalibrationStatus.unavailable,
+          CalibrationStatus.unavailable,
+        ]),
+        isTrue,
+      );
+    });
+
+    test('空リストなら真(判定対象がいない)', () {
+      expect(isCalibrationComplete(const []), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
- キャリブレーション状況を全員分表示するようにし(完了/未実施/センサー非対応の3状態)、参加者一覧に集計と未完了者名を表示
- センサー非対応の端末は完了判定から除外し、全員完了までホストの「ゲーム開始」を無効化
- 気圧センサーの有無をRTDB(pressureSensorAvailable)に記録し、他端末からも判定できるようにした
- 判定ロジックをcalibration_status.dartに純粋関数として切り出し、テストを追加
- 「鬼にする」指名を、対象者が受諾するまでホスト側で取り消せるようにした(cancelDemonNomination)