### PR TITLE
night-runがCLAUDE_CODE_OAUTH_TOKENにも対応

### DIFF
--- a/night-run/README.md
+++ b/night-run/README.md
@@ -23,14 +23,29 @@ night-run/run.sh build
 
 ### 2. 認証情報の準備（ホスト側の環境変数。コミットしない）
 
+`claude -p` の認証は次の**どちらか一方**でよい。
+
 | 変数 | 用途 | 取得方法 |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | コンテナ内の `claude -p` の認証 | Anthropic Consoleで発行するAPIキー。**このMacで対話的に使っているサブスクリプションのOAuthログインとは別物**。非対話実行にはAPIキー方式が必要 |
-| `GH_TOKEN` | `git push` / `gh pr create` の認証 | `kajiLabTeam/kakureru` への書き込み権限を持つGitHub Personal Access Token（`repo`スコープ） |
+| `ANTHROPIC_API_KEY` | コンテナ内の `claude -p` の認証(APIキー方式) | Anthropic Consoleで発行するAPIキー。従量課金でサブスクリプションとは別会計 |
+| `CLAUDE_CODE_OAUTH_TOKEN` | コンテナ内の `claude -p` の認証(サブスクリプション方式) | `claude setup-token` で発行する長期トークン。追加の課金なしでサブスクリプションの利用枠を使う代わりに、**レート制限は人間の対話利用ペースを想定したものなので、1晩で複数タスクを回すと途中で制限に達しやすい**(その場合はnight_runner.pyのbackoffで数回リトライした上でそのタスクは`failed`として安全に終わる。締切までに終わらないタスクが出うる、という程度のリスク) |
+
+`GH_TOKEN` は必須。
+
+| 変数 | 用途 | 取得方法 |
+|---|---|---|
+| `GH_TOKEN` | `git push` / `gh pr create` / `gh issue view` の認証 | `kajiLabTeam/kakureru` への書き込み権限を持つGitHub Personal Access Token（`repo`スコープ）。ホストで既に`gh auth login`済みなら `gh auth token` の値をそのまま使ってもよい |
+
+値はプロジェクトのファイルには書かない。ホームディレクトリなど**git管理外の場所**に環境変数ファイルを作り、使うたびに`source`する運用を推奨する(例: `~/.night-run-secrets.env`、`chmod 600`)。
 
 ```sh
-export ANTHROPIC_API_KEY="..."
+# ~/.night-run-secrets.env (例)
+export CLAUDE_CODE_OAUTH_TOKEN="..."   # または ANTHROPIC_API_KEY
 export GH_TOKEN="..."
+```
+
+```sh
+source ~/.night-run-secrets.env && night-run/run.sh start
 ```
 
 ### 3. ホスト側で `gh` を使えるようにする（ヒアリングSkill・起票Skill用）

--- a/night-run/docker/entrypoint.sh
+++ b/night-run/docker/entrypoint.sh
@@ -4,7 +4,10 @@
 set -euo pipefail
 
 : "${GH_TOKEN:?GH_TOKEN が設定されていない(GitHub操作に必須)}"
-: "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY が設定されていない(claude -pの認証に必須)}"
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+    echo "FATAL: ANTHROPIC_API_KEY か CLAUDE_CODE_OAUTH_TOKEN のどちらかが必要(claude -pの認証に必須)" >&2
+    exit 1
+fi
 
 echo "[entrypoint] applying network egress allowlist..."
 /usr/local/bin/init-firewall.sh
@@ -39,13 +42,19 @@ fi
 chown -R runner:runner /workdir
 
 echo "[entrypoint] starting night_runner.py as non-root user 'runner'..."
-exec runuser -u runner -- env \
-    "HOME=/home/runner" \
-    "PATH=$PATH" \
-    "NIGHT_RUNNER_SANDBOX=1" \
-    "NIGHT_RUN_REPO_DIR=$REPO_DIR" \
-    "NIGHT_RUN_STATE_FILE=$STATE_FILE_PATH" \
-    "NIGHT_RUN_MAX_BUDGET_USD=${NIGHT_RUN_MAX_BUDGET_USD:-15}" \
-    "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
-    "GH_TOKEN=$GH_TOKEN" \
-    python3 "$REPO_DIR/night-run/night_runner.py"
+runner_env=(
+    "HOME=/home/runner"
+    "PATH=$PATH"
+    "NIGHT_RUNNER_SANDBOX=1"
+    "NIGHT_RUN_REPO_DIR=$REPO_DIR"
+    "NIGHT_RUN_STATE_FILE=$STATE_FILE_PATH"
+    "NIGHT_RUN_MAX_BUDGET_USD=${NIGHT_RUN_MAX_BUDGET_USD:-15}"
+    "GH_TOKEN=$GH_TOKEN"
+)
+# ANTHROPIC_API_KEY(APIキー課金)かCLAUDE_CODE_OAUTH_TOKEN(claude setup-tokenで発行する
+# サブスクリプション連携の長期トークン)のどちらかで動く。両方渡さない
+# (空文字を渡すと「設定されているが空」という別の状態になり、未設定より紛らわしいため)。
+[ -n "${ANTHROPIC_API_KEY:-}" ] && runner_env+=("ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY")
+[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && runner_env+=("CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN")
+
+exec runuser -u runner -- env "${runner_env[@]}" python3 "$REPO_DIR/night-run/night_runner.py"

--- a/night-run/run.sh
+++ b/night-run/run.sh
@@ -11,7 +11,7 @@
 #   night-run/run.sh rm      # 停止済みコンテナを削除する(次のstartのため)
 #
 # 必須の環境変数(ホスト側で事前に export しておく。詳細はnight-run/README.md):
-#   ANTHROPIC_API_KEY   claude -p の認証
+#   ANTHROPIC_API_KEY か CLAUDE_CODE_OAUTH_TOKEN のどちらか   claude -p の認証
 #   GH_TOKEN            git push / gh pr create の認証(対象repoへの書き込み権限が要る)
 set -euo pipefail
 
@@ -36,21 +36,28 @@ case "$cmd" in
         docker build -t "$IMAGE_NAME" "$REPO_ROOT/night-run/docker"
         ;;
     start)
-        require_env ANTHROPIC_API_KEY
         require_env GH_TOKEN
+        if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            echo "エラー: ANTHROPIC_API_KEY か CLAUDE_CODE_OAUTH_TOKEN のどちらかが設定されていない。night-run/README.md のセットアップ手順を確認すること。" >&2
+            exit 1
+        fi
         if [ ! -f "$STATE_DIR/night-run-state.json" ]; then
             echo "エラー: $STATE_DIR/night-run-state.json が無い。先にヒアリングSkillで作成すること。" >&2
             exit 1
         fi
         mkdir -p "$STATE_DIR"
         docker volume create "$VOLUME_NAME" >/dev/null
+
+        docker_env_args=(-e GH_TOKEN)
+        [ -n "${ANTHROPIC_API_KEY:-}" ] && docker_env_args+=(-e ANTHROPIC_API_KEY)
+        [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && docker_env_args+=(-e CLAUDE_CODE_OAUTH_TOKEN)
+
         docker run -d \
             --name "$CONTAINER_NAME" \
             --cap-add=NET_ADMIN --cap-add=NET_RAW \
             -v "$VOLUME_NAME:/workdir" \
             -v "$STATE_DIR:/workdir/state" \
-            -e ANTHROPIC_API_KEY \
-            -e GH_TOKEN \
+            "${docker_env_args[@]}" \
             -e NIGHT_RUN_REPO_URL="${NIGHT_RUN_REPO_URL:-https://github.com/kajiLabTeam/kakureru.git}" \
             -e NIGHT_RUN_MAX_BUDGET_USD="${NIGHT_RUN_MAX_BUDGET_USD:-15}" \
             "$IMAGE_NAME"


### PR DESCRIPTION
## 概要
`claude -p`の認証をAPIキー専用から、`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`(`claude setup-token`で発行するサブスクリプション連携の長期トークン)のどちらでも動くように変更。

## 変更点
- `night-run/docker/entrypoint.sh`: どちらか一方が設定されていればOKにfail-closedチェックを変更。設定されている方だけをコンテナ内プロセスへ渡す
- `night-run/run.sh`: 同様にどちらか一方を要求し、`docker run`に設定されている方だけを渡す
- `night-run/README.md`: 認証情報セクションを更新。`CLAUDE_CODE_OAUTH_TOKEN`利用時のトレードオフ(サブスクリプションのレート制限は対話利用ペース想定なので、1晩に複数タスク回すと制限に達しやすい。ただしnight_runner.py側のbackoff/failed処理で安全に終わる)を明記。秘密情報はプロジェクト外のファイルに置いて`source`する運用を推奨する記載を追加

## テスト計画
- [x] 実際にDockerコンテナ内で`CLAUDE_CODE_OAUTH_TOKEN`のみを使い`claude -p`が認証・応答することを確認(キーチェーンの無いLinuxコンテナ内で検証)
- [x] `GH_TOKEN`のみ/認証情報なし/`CLAUDE_CODE_OAUTH_TOKEN`のみ、の各パターンでentrypoint.shのfail-closed動作を確認
- [x] `python3 night-run/test_night_runner.py`(22件全通過、night_runner.py自体は無変更)
- [x] `python3 scripts/verify_safety_net.py`(既存の無関係な1件を除き全通過)

🤖 Generated with [Claude Code](https://claude.com/claude-code)