### PR TITLE
どの画面が鬼側かひと目で分かるようにする

### DIFF
--- a/lib/features/room/role_theme.dart
+++ b/lib/features/room/role_theme.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:kakureru/features/room/model/room_user.dart';
+
+/// 役割(鬼/逃走者)を一目で見分けるための表示情報(ヘッダー背景色・文言・アイコン)。
+///
+/// 「画面を見ただけでは自分が鬼か逃走者か分かりにくい」という課題(issue #12)に
+/// 対応するためのもの。docs/ui-mockup-2a.html の画面03(鬼)・画面04(逃走者)の
+/// 配色(鬼=赤 #E5484D、逃走者=緑 #4A9C5D)と「あなたは 鬼/逃走者」の文言に合わせている。
+@immutable
+class RoleTheme {
+  /// [color] [label] [icon] をまとめて指定する。
+  const RoleTheme({
+    required this.color,
+    required this.label,
+    required this.icon,
+  });
+
+  /// ヘッダーの背景色。
+  final Color color;
+
+  /// ヘッダーに表示する「あなたは 鬼/逃走者」の文言。
+  final String label;
+
+  /// ヘッダーに添えるアイコン。
+  final IconData icon;
+}
+
+const _demonColor = Color(0xFFE5484D);
+const _fugitiveColor = Color(0xFF4A9C5D);
+
+/// 役割に応じたヘッダー表示情報を返す。
+RoleTheme roleThemeOf(UserRole role) {
+  switch (role) {
+    case UserRole.demon:
+      return const RoleTheme(
+        color: _demonColor,
+        label: 'あなたは 鬼',
+        icon: Icons.local_fire_department,
+      );
+    case UserRole.fugitive:
+      return const RoleTheme(
+        color: _fugitiveColor,
+        label: 'あなたは 逃走者',
+        icon: Icons.directions_run,
+      );
+  }
+}

--- a/lib/features/room/role_theme.dart
+++ b/lib/features/room/role_theme.dart
@@ -1,28 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:kakureru/features/room/model/room_user.dart';
+
+part 'role_theme.freezed.dart';
 
 /// 役割(鬼/逃走者)を一目で見分けるための表示情報(ヘッダー背景色・文言・アイコン)。
 ///
 /// 「画面を見ただけでは自分が鬼か逃走者か分かりにくい」という課題(issue #12)に
 /// 対応するためのもの。docs/ui-mockup-2a.html の画面03(鬼)・画面04(逃走者)の
 /// 配色(鬼=赤 #E5484D、逃走者=緑 #4A9C5D)と「あなたは 鬼/逃走者」の文言に合わせている。
-@immutable
-class RoleTheme {
-  /// [color] [label] [icon] をまとめて指定する。
-  const RoleTheme({
-    required this.color,
-    required this.label,
-    required this.icon,
-  });
-
-  /// ヘッダーの背景色。
-  final Color color;
-
-  /// ヘッダーに表示する「あなたは 鬼/逃走者」の文言。
-  final String label;
-
-  /// ヘッダーに添えるアイコン。
-  final IconData icon;
+@freezed
+abstract class RoleTheme with _$RoleTheme {
+  const factory RoleTheme({
+    required Color color,
+    required String label,
+    required IconData icon,
+  }) = _RoleTheme;
 }
 
 const _demonColor = Color(0xFFE5484D);

--- a/lib/features/room/role_theme.freezed.dart
+++ b/lib/features/room/role_theme.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'role_theme.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$RoleTheme {
+
+ Color get color; String get label; IconData get icon;
+/// Create a copy of RoleTheme
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RoleThemeCopyWith<RoleTheme> get copyWith => _$RoleThemeCopyWithImpl<RoleTheme>(this as RoleTheme, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RoleTheme&&(identical(other.color, color) || other.color == color)&&(identical(other.label, label) || other.label == label)&&(identical(other.icon, icon) || other.icon == icon));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,color,label,icon);
+
+@override
+String toString() {
+  return 'RoleTheme(color: $color, label: $label, icon: $icon)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RoleThemeCopyWith<$Res>  {
+  factory $RoleThemeCopyWith(RoleTheme value, $Res Function(RoleTheme) _then) = _$RoleThemeCopyWithImpl;
+@useResult
+$Res call({
+ Color color, String label, IconData icon
+});
+
+
+
+
+}
+/// @nodoc
+class _$RoleThemeCopyWithImpl<$Res>
+    implements $RoleThemeCopyWith<$Res> {
+  _$RoleThemeCopyWithImpl(this._self, this._then);
+
+  final RoleTheme _self;
+  final $Res Function(RoleTheme) _then;
+
+/// Create a copy of RoleTheme
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? color = null,Object? label = null,Object? icon = null,}) {
+  return _then(_self.copyWith(
+color: null == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as Color,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,icon: null == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
+as IconData,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RoleTheme].
+extension RoleThemePatterns on RoleTheme {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RoleTheme value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RoleTheme() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RoleTheme value)  $default,){
+final _that = this;
+switch (_that) {
+case _RoleTheme():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RoleTheme value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RoleTheme() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Color color,  String label,  IconData icon)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RoleTheme() when $default != null:
+return $default(_that.color,_that.label,_that.icon);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Color color,  String label,  IconData icon)  $default,) {final _that = this;
+switch (_that) {
+case _RoleTheme():
+return $default(_that.color,_that.label,_that.icon);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Color color,  String label,  IconData icon)?  $default,) {final _that = this;
+switch (_that) {
+case _RoleTheme() when $default != null:
+return $default(_that.color,_that.label,_that.icon);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _RoleTheme implements RoleTheme {
+  const _RoleTheme({required this.color, required this.label, required this.icon});
+  
+
+@override final  Color color;
+@override final  String label;
+@override final  IconData icon;
+
+/// Create a copy of RoleTheme
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RoleThemeCopyWith<_RoleTheme> get copyWith => __$RoleThemeCopyWithImpl<_RoleTheme>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RoleTheme&&(identical(other.color, color) || other.color == color)&&(identical(other.label, label) || other.label == label)&&(identical(other.icon, icon) || other.icon == icon));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,color,label,icon);
+
+@override
+String toString() {
+  return 'RoleTheme(color: $color, label: $label, icon: $icon)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RoleThemeCopyWith<$Res> implements $RoleThemeCopyWith<$Res> {
+  factory _$RoleThemeCopyWith(_RoleTheme value, $Res Function(_RoleTheme) _then) = __$RoleThemeCopyWithImpl;
+@override @useResult
+$Res call({
+ Color color, String label, IconData icon
+});
+
+
+
+
+}
+/// @nodoc
+class __$RoleThemeCopyWithImpl<$Res>
+    implements _$RoleThemeCopyWith<$Res> {
+  __$RoleThemeCopyWithImpl(this._self, this._then);
+
+  final _RoleTheme _self;
+  final $Res Function(_RoleTheme) _then;
+
+/// Create a copy of RoleTheme
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? color = null,Object? label = null,Object? icon = null,}) {
+  return _then(_RoleTheme(
+color: null == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as Color,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,icon: null == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
+as IconData,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -19,6 +19,7 @@ import 'package:kakureru/features/room/model/room.dart';
 import 'package:kakureru/features/room/model/room_setting.dart';
 import 'package:kakureru/features/room/model/room_user.dart';
 import 'package:kakureru/features/room/rectangle_area.dart';
+import 'package:kakureru/features/room/role_theme.dart';
 import 'package:kakureru/features/room/role_visibility.dart';
 import 'package:kakureru/features/room/view/game_result_page.dart';
 import 'package:kakureru/features/room/view_model/room_view_model.dart';
@@ -51,6 +52,11 @@ class GamePage extends HookConsumerWidget {
     final offset = ref.watch(serverTimeOffsetProvider).value ?? 0;
     final locationState = ref.watch(locationViewModelProvider);
     final myUid = FirebaseAuth.instance.currentUser?.uid;
+    // 「自分がどちらの役割か」はヘッダーの色・文言で常に一目で分かるようにする
+    // (issue #12)。roomAsyncがまだloading/errorの間は役割が確定しないため、
+    // その場合はヘッダーを役割色に染めず既定表示のままにする。
+    final headerRole = _roleOf(room?.users ?? const [], myUid);
+    final headerRoleTheme = headerRole != null ? roleThemeOf(headerRole) : null;
 
     // 残り時間を1秒ごとに再計算するためのティッカー。
     // .info/serverTimeOffset 自体はズレが変化した時にしか流れてこないため、
@@ -181,7 +187,19 @@ class GamePage extends HookConsumerWidget {
     // 閉じてしまうと位置送信が止まるため、最小化に倒す(プラグイン推奨パターン)。
     return WithForegroundTask(
       child: Scaffold(
-        appBar: AppBar(title: const Text('ゲーム中')),
+        appBar: AppBar(
+          backgroundColor: headerRoleTheme?.color,
+          foregroundColor: headerRoleTheme != null ? Colors.white : null,
+          title: Text(headerRoleTheme?.label ?? 'ゲーム中'),
+          actions: headerRoleTheme != null
+              ? [
+                  Padding(
+                    padding: const EdgeInsets.only(right: 16),
+                    child: Icon(headerRoleTheme.icon),
+                  ),
+                ]
+              : null,
+        ),
         body: roomAsync.when(
           data: (room) {
             final now = serverNowMillis(offset);

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -53,8 +53,11 @@ class GamePage extends HookConsumerWidget {
     final locationState = ref.watch(locationViewModelProvider);
     final myUid = FirebaseAuth.instance.currentUser?.uid;
     // 「自分がどちらの役割か」はヘッダーの色・文言で常に一目で分かるようにする
-    // (issue #12)。roomAsyncがまだloading/errorの間は役割が確定しないため、
-    // その場合はヘッダーを役割色に染めず既定表示のままにする。
+    // (issue #12)。roomAsyncがまだloading/errorの間、または自分がusersに
+    // 見つからない間は役割が確定しないため、その場合はヘッダーを役割色に
+    // 染めず既定表示のままにする。RTDB上は参加時に必ずroleが書き込まれる
+    // (docs/rtdb-schema.md)ため、usersに見つかった時点でのroleの既定値
+    // フォールバック(RoomUser.role参照)は実運用では発生しない想定。
     final headerRole = _roleOf(room?.users ?? const [], myUid);
     final headerRoleTheme = headerRole != null ? roleThemeOf(headerRole) : null;
 

--- a/test/features/room/role_theme_test.dart
+++ b/test/features/room/role_theme_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kakureru/features/room/model/room_user.dart';
+import 'package:kakureru/features/room/role_theme.dart';
+
+void main() {
+  group('roleThemeOf', () {
+    test('鬼は赤系の色と「あなたは 鬼」の文言になる', () {
+      final theme = roleThemeOf(UserRole.demon);
+      expect(theme.color, const Color(0xFFE5484D));
+      expect(theme.label, 'あなたは 鬼');
+    });
+
+    test('逃走者は緑系の色と「あなたは 逃走者」の文言になる', () {
+      final theme = roleThemeOf(UserRole.fugitive);
+      expect(theme.color, const Color(0xFF4A9C5D));
+      expect(theme.label, 'あなたは 逃走者');
+    });
+
+    test('鬼と逃走者で色・文言・アイコンがすべて異なる(一目で見分けられる)', () {
+      final demon = roleThemeOf(UserRole.demon);
+      final fugitive = roleThemeOf(UserRole.fugitive);
+      expect(demon.color, isNot(fugitive.color));
+      expect(demon.label, isNot(fugitive.label));
+      expect(demon.icon, isNot(fugitive.icon));
+    });
+  });
+}


### PR DESCRIPTION
## 概要

issue #12 の対応(未完了、draft)。ゲーム中画面(`GamePage`)のヘッダーを、自分の役割(鬼/逃走者)に応じて背景色・文言・アイコンで染め、画面を見ただけで自分の役割が一目で分かるようにする。

配色・文言は issue コメントで示された `docs/ui-mockup-2a.html` の画面03(鬼)・画面04(逃走者)の案(鬼=赤 #E5484D、逃走者=緑 #4A9C5D、「あなたは 鬼/逃走者」)に合わせた。

## 完了した内容

- `lib/features/room/role_theme.dart`: 役割ごとのヘッダー表示情報(色・文言・アイコン)を返す `roleThemeOf` を追加(Freezedの `RoleTheme` クラスを使用、AGENTS.mdのデータクラス規約に準拠)。
- `lib/features/room/view/game_page.dart`: `GamePage` の `AppBar` を、自分の役割に応じて `roleThemeOf` の色・文言・アイコンで表示するよう変更。役割未確定時は従来通り「ゲーム中」表示にフォールバック。
- `test/features/room/role_theme_test.dart`: `roleThemeOf` の単体テストを追加。
- `flutter test`(122件全て成功)・`flutter analyze`(新規の警告・エラーなし、既存のinfoレベルlintのベースライン件数と同水準)を確認済み。

## 未完了の点

レビューで以下のmust-fix指摘が2ラウンド連続で解消できず、運用ルール(同一指摘2回連続で打ち切り)によりdraftとした。

- **`headerRole` が「役割未確定」と「役割確定済みで逃走者」を区別できない問題**: `RoomUser.role` は `@Default(UserRole.fugitive)` かつ `@JsonKey(unknownEnumValue: UserRole.fugitive)` のため、RTDB上の `role` が欠落・不正な値だった場合にも `fugitive`(緑「あなたは 逃走者」)として確定表示してしまう。コメントで「実運用では発生しない想定」と補足したが、`unknownEnumValue` の存在自体がこの前提に反するとレビューで指摘され、未解消。

## 次にやるべきこと

- `headerRole` 用に「未確定」を型で表現する対応を検討する。issueのスコープ(「含まない: 役割そのものの仕様変更」)に配慮しつつ、例えば `Room.fromMap` の生データ(`usersRaw`)から `role` キーの有無を別途調べて `game_page.dart` 側だけで `UserRole?` (真にnullable)を算出する、といった `RoomUser` モデル自体を変更しない対応が候補。
- (nice-to-have)`GamePage` の `AppBar` が役割に応じて正しく配線されていることを検証するウィジェットテストの追加。
- (nice-to-have)`RoleTheme` の色(#E5484D/#4A9C5D)と既存の `_colorForRole`(`Colors.red`/`Colors.green`、マーカー表示用)の色定義が別々に存在しており、二重管理になっている点の整理。