### PR TITLE
fix: コンテナ再利用時に古いコードで起動してしまう不具合を修正

### DIFF
--- a/night-run/docker/entrypoint.sh
+++ b/night-run/docker/entrypoint.sh
@@ -27,8 +27,15 @@ if [ ! -d "$REPO_DIR/.git" ]; then
     echo "[entrypoint] cloning $REPO_URL into $REPO_DIR ..."
     git clone "$REPO_URL" "$REPO_DIR"
 else
-    echo "[entrypoint] $REPO_DIR already exists, fetching..."
+    # fetchだけだとworking treeは前回終了時点のまま(前夜の古いnight_runner.py等)。
+    # これから起動するpython3プロセスはファイルを起動時に一度だけ読み込むので、
+    # ここでorigin/mainに合わせておかないと、night_runner.py自体の更新が
+    # (git_cleanup()が後で効くとしても)このプロセスには反映されない。
+    echo "[entrypoint] $REPO_DIR already exists, syncing to latest origin/main..."
     git -C "$REPO_DIR" fetch origin
+    git -C "$REPO_DIR" checkout -f main
+    git -C "$REPO_DIR" reset --hard origin/main
+    git -C "$REPO_DIR" clean -fd
 fi
 
 mkdir -p "$STATE_DIR"


### PR DESCRIPTION
## 概要
`night-run/run.sh start`はDocker named volumeを夜をまたいで使い回す設計。2回目以降の起動時、entrypoint.shは`git fetch`しかしておらず、working treeは前回終了時点のまま(=night_runner.py自体も古いまま)でpython3プロセスが起動していた。git_cleanup()は後で効くが、それは既に起動済みのpythonプロセスには反映されない。

## 変更点
- 既存クローンがある場合も、fetch後に`checkout -f main && reset --hard origin/main && clean -fd`でorigin/mainに揃えてからnight_runner.pyを起動するよう修正

## テスト計画
- [x] shell構文チェック済み
- [x] 次回の`night-run/run.sh start`実行(本番投入)で実際に効果を確認する