### PR TITLE
fix: claude -pがワークスペース信頼ダイアログで落ちる不具合を修正

### DIFF
--- a/night-run/docker/entrypoint.sh
+++ b/night-run/docker/entrypoint.sh
@@ -48,6 +48,17 @@ fi
 
 chown -R runner:runner /workdir
 
+# Claude Codeには--dangerously-skip-permissionsとは別に「ワークスペース信頼」の
+# ゲートがあり、初回はインタラクティブな承認が要る(非対話実行だと素通りできず
+# claude -pがエラーで落ちる)。/home/runnerはnamed volumeではなくコンテナ起動の
+# たびに作り直されるため、毎回明示的に信頼済み扱いにしておく。
+echo "[entrypoint] pre-accepting Claude Code workspace trust for $REPO_DIR..."
+mkdir -p /home/runner
+cat > /home/runner/.claude.json <<JSON
+{"projects": {"$REPO_DIR": {"hasTrustDialogAccepted": true}}}
+JSON
+chown runner:runner /home/runner/.claude.json
+
 echo "[entrypoint] starting night_runner.py as non-root user 'runner'..."
 runner_env=(
     "HOME=/home/runner"


### PR DESCRIPTION
## 概要
本番実行(issue #8〜)のtask-1が以下のエラーで即failedになった:

```
Ignoring 6 permissions.allow entries from .claude/settings.json: this workspace has not been trusted.
Run Claude Code interactively here once and accept the trust dialog, or set
projects["/workdir/repo"].hasTrustDialogAccepted: true in /home/runner/.claude.json.
```

`--dangerously-skip-permissions`はツール実行の確認プロンプトをバイパスするが、Claude Codeの「ワークスペース信頼」はそれとは別のゲートで、非対話実行では自動的に通らない。`/home/runner`はnamed volumeではなくコンテナ起動のたびに作り直されるため、この問題は毎回起きる。

## 変更点
- entrypoint.shで、night_runner.py起動前に`/home/runner/.claude.json`へ`projects["/workdir/repo"].hasTrustDialogAccepted: true`を書き込むようにした

## テスト計画
- [x] 実機コンテナ内で、修正前は警告が出ていたのが修正後は出ないことを確認済み(`claude -p`が`is_error:false`で正常応答)