### PR TITLE
全画面の見た目をUI改修モックに合わせて改善

### DIFF
--- a/docs/ui-mockup-2a.html
+++ b/docs/ui-mockup-2a.html
@@ -29,7 +29,7 @@ a{color:#2a78d6;text-decoration:none}a:hover{color:#1a5cb0}
 
 <div class="dv-opt" id="2a" style="width:100%">
 <div class="dv-olabel"><a class="dv-oid" href="#2a">2a</a>実画面ベースの改修モック（8画面）— 赤=鬼 / 青=自分 / 緑=逃走者、ルームコードは4桁、地図はOSMタイル</div>
-<div class="dv-card" style="padding:26px;background:#fafaf7">
+<div style="box-sizing: border-box; display: flex; flex-direction: column; gap: 9px; justify-content: normal; align-items: normal"><div class="dv-card" style="padding:26px;background:#fafaf7">
 <div style="display:flex;flex-wrap:wrap;gap:26px;align-items:flex-start">
 
   <!-- 01 ホーム -->
@@ -79,7 +79,7 @@ a{color:#2a78d6;text-decoration:none}a:hover{color:#1a5cb0}
           <div style="display:flex;gap:7px;align-items:center;color:#c88a1e"><span>◻</span>キャリブレーション 3/4人</div>
         </div>
       </div>
-      <div style="flex:1;overflow:hidden;padding:8px 12px;display:flex;flex-direction:column;gap:6px">
+      <div style="flex:1;overflow-y:auto;padding:8px 12px;display:flex;flex-direction:column;gap:6px;min-height:0">
         <div style="font-size:10px;color:#888">参加者 4人</div>
         <div style="display:flex;align-items:center;gap:8px;border:2px solid #e5484d;border-radius:11px;padding:8px 10px;background:rgba(229,72,77,.05)">
           <div style="width:26px;height:26px;border-radius:50%;background:#e5484d;color:#fff;display:flex;align-items:center;justify-content:center;font-size:12px">り</div>
@@ -146,47 +146,58 @@ a{color:#2a78d6;text-decoration:none}a:hover{color:#1a5cb0}
       </div>
       <div style="border-top:2px solid #2b2b2b;padding:10px 12px;display:flex;flex-direction:column;gap:8px">
         <div style="display:flex;justify-content:space-between;align-items:center">
-          <div style="font-size:11px;color:#888">いま追う相手</div>
-          <div style="font-size:10px;color:#888">いちばん近い逃走者</div>
+          <div style="font-size:11px;color:#888">逃走者を選んで詳細を見る</div>
+          
         </div>
-        <div style="display:flex;gap:10px;align-items:stretch;border:2px solid #2b2b2b;border-radius:12px;padding:10px">
-          <div style="display:flex;flex-direction:column;align-items:center;gap:4px;width:56px">
-            <div style="width:30px;height:30px;border-radius:50%;background:#4a9c5d;color:#fff;display:flex;align-items:center;justify-content:center;font-size:13px">ゆ</div>
-            <div style="font-size:11px">ゆい</div>
+        <div style="display:flex;gap:6px">
+          <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;border:2px solid #4a9c5d;border-radius:10px;padding:7px 4px;background:rgba(74,156,93,.07)">
+            <div style="width:24px;height:24px;border-radius:50%;background:#4a9c5d;color:#fff;display:flex;align-items:center;justify-content:center;font-size:11px">ゆ</div>
+            <div style="font-size:10.5px">ゆい</div>
+            <div style="font-size:9px;color:#e5484d">近い</div>
           </div>
-          <div style="width:2px;background:#eee"></div>
-          <div style="display:flex;flex-direction:column;align-items:center;gap:3px;width:52px">
-            <div style="font-size:9.5px;color:#888">上下</div>
-            <div style="position:relative;width:26px;flex:1;min-height:44px;border:1.5px solid #ddd;border-radius:6px">
-              <div style="position:absolute;left:0;right:0;top:50%;height:3px;background:#3b82f6"></div>
-              <div style="position:absolute;left:50%;top:9px;transform:translateX(-50%);width:14px;height:14px;border-radius:50%;background:#4a9c5d;border:2px solid #fff"></div>
-            </div>
-            <div style="font-size:10px;color:#2b2b2b">＋4m 上</div>
+          <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;border:2px solid transparent;border-radius:10px;padding:7px 4px">
+            <div style="width:24px;height:24px;border-radius:50%;background:#4a9c5d;color:#fff;display:flex;align-items:center;justify-content:center;font-size:11px">た</div>
+            <div style="font-size:10.5px;color:#888">たくみ</div>
+            <div style="font-size:9px;color:#aaa">遠い</div>
           </div>
-          <div style="width:2px;background:#eee"></div>
-          <div style="flex:1;display:flex;flex-direction:column;gap:4px;justify-content:center">
-            <div style="font-size:9.5px;color:#888">Wi-Fi距離感</div>
-            <div style="font-size:15px;color:#e5484d">近い</div>
-            <div style="display:flex;gap:3px;align-items:flex-end;height:16px">
-              <div style="flex:1;height:60%;background:#3b82f6;border-radius:2px"></div>
-              <div style="flex:1;height:70%;background:#4a9c5d;border-radius:2px"></div>
-              <div style="width:4px"></div>
-              <div style="flex:1;height:90%;background:#3b82f6;border-radius:2px"></div>
-              <div style="flex:1;height:85%;background:#4a9c5d;border-radius:2px"></div>
-              <div style="width:4px"></div>
-              <div style="flex:1;height:45%;background:#3b82f6;border-radius:2px"></div>
-              <div style="flex:1;height:50%;background:#4a9c5d;border-radius:2px"></div>
-            </div>
-            <div style="font-size:9px;color:#aaa">青=自分 / 緑=相手 のRSSI（3AP）</div>
+          <div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;border:2px solid transparent;border-radius:10px;padding:7px 4px;opacity:.5">
+            <div style="width:24px;height:24px;border-radius:50%;background:#4a9c5d;color:#fff;display:flex;align-items:center;justify-content:center;font-size:11px">そ</div>
+            <div style="font-size:10.5px;color:#888">そら</div>
+            <div style="font-size:9px;color:#aaa">検知なし</div>
           </div>
         </div>
-        <div style="display:flex;gap:7px;font-size:10.5px;color:#888">
-          <div style="flex:1;border:1.5px solid #ddd;border-radius:8px;padding:5px;text-align:center">たくみ 遠い ↓</div>
-          <div style="flex:1;border:1.5px solid #ddd;border-radius:8px;padding:5px;text-align:center">そら 検知なし</div>
+        <div style="border:2px solid #2b2b2b;border-radius:12px;padding:10px;display:flex;flex-direction:column;gap:8px">
+          <div style="font-size:11px;color:#2b2b2b">ゆい の詳細</div>
+          <div style="display:flex;gap:10px;align-items:stretch">
+            <div style="display:flex;flex-direction:column;align-items:center;gap:3px;width:60px">
+              <div style="font-size:9.5px;color:#888">上下</div>
+              <div style="position: relative; width: 61px; flex: 1; min-height: 60px; border: 1.5px solid #ddd; border-radius: 6px; height: 58px">
+                <div style="position:absolute;left:0;right:0;top:50%;height:3px;background:#3b82f6"></div>
+                <div style="position:absolute;left:50%;top:12px;transform:translateX(-50%);width:14px;height:14px;border-radius:50%;background:#4a9c5d;border:2px solid #fff"></div>
+              </div>
+              
+            </div>
+            <div style="width:2px;background:#eee"></div>
+            <div style="flex:1;display:flex;flex-direction:column;gap:4px;justify-content:center">
+              <div style="font-size:9.5px;color:#888">Wi-Fi距離感</div>
+              <div style="font-size:15px;color:#e5484d">近い</div>
+              <div style="display:flex;gap:3px;align-items:flex-end;height:18px">
+                <div style="flex:1;height:60%;background:#3b82f6;border-radius:2px"></div>
+                <div style="flex:1;height:70%;background:#4a9c5d;border-radius:2px"></div>
+                <div style="width:4px"></div>
+                <div style="flex:1;height:90%;background:#3b82f6;border-radius:2px"></div>
+                <div style="flex:1;height:85%;background:#4a9c5d;border-radius:2px"></div>
+                <div style="width:4px"></div>
+                <div style="flex:1;height:45%;background:#3b82f6;border-radius:2px"></div>
+                <div style="flex:1;height:50%;background:#4a9c5d;border-radius:2px"></div>
+              </div>
+              <div style="font-size:9px;color:#aaa">青=自分 / 緑=相手 のRSSI（3AP）</div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div style="font:11px/1.5 system-ui,sans-serif;color:#777;background:#fff;border:1px solid #eee;border-radius:8px;padding:8px 10px">改善：ピンに名前ラベル。「いま追う相手」を1人に固定し、上下バーとWi-Fiを同じカードにまとめる（3段階/RSSIの切替タブを廃止し両方表示）。他の人は下に一行ずつ。</div>
+    <div style="font:11px/1.5 system-ui,sans-serif;color:#777;background:#fff;border:1px solid #eee;border-radius:8px;padding:8px 10px">改善：ピンに名前ラベル。人数が増えても見やすいよう、逃走者を上部のタブ（人型チップ）で切り替え、選んだ1人だけの上下バー＋Wi-Fiを下の詳細カードに表示。検知なしの人は薄く表示。</div>
   </div>
 
   <!-- 04 ゲーム中・逃走者 -->
@@ -216,16 +227,13 @@ a{color:#2a78d6;text-decoration:none}a:hover{color:#1a5cb0}
           <div style="width:13px;height:13px;border-radius:50%;background:#4a9c5d;border:2.5px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,.35)"></div>
         </div>
       </div>
-      <div style="border-top:2px solid #2b2b2b;padding:11px 13px;display:flex;flex-direction:column;gap:8px">
+      <div style="border-top: 2px solid #2b2b2b; padding: 11px 13px; display: flex; flex-direction: column; gap: 8px; width: 251px; height: 127px">
         <div style="border:2px dashed #ccc;border-radius:12px;padding:14px 10px;display:flex;flex-direction:column;align-items:center;gap:4px">
           <div style="font-size:20px;opacity:.35">👹</div>
           <div style="font-size:12.5px;color:#888">鬼の位置はまだ見えません</div>
           <div style="font-size:10px;color:#aaa">放出から30秒後に表示されます</div>
         </div>
-        <div style="display:flex;align-items:center;gap:8px;background:#f7f7f5;border-radius:10px;padding:8px 10px">
-          <div style="font-size:13px">📡</div>
-          <div style="font-size:10.5px;color:#888">BLEは残り5分から有効。3m以内に鬼が来ると通知されます</div>
-        </div>
+        
       </div>
     </div>
     <div style="font:11px/1.5 system-ui,sans-serif;color:#777;background:#fff;border:1px solid #eee;border-radius:8px;padding:8px 10px">改善：見えない理由（役割による可視性ディレイ）を空欄ではなく明示。放出前は残り時間の意味が変わることをバナーで補足。</div>
@@ -348,7 +356,7 @@ a{color:#2a78d6;text-decoration:none}a:hover{color:#1a5cb0}
   </div>
 
 </div>
-</div>
+</div></div>
 </div>
 
 </div>

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// docs/ui-mockup-2a.html のトーン(白背景・#2b2b2b の太めの黒枠・角丸10〜16・
+/// グレーの補助テキスト)をアプリ全体に適用する共通テーマ。
+/// 役割ごとの色(鬼=赤/逃走者=緑/自分=青)は各画面・role_theme.dart側で個別に扱う。
+const appInk = Color(0xFF2B2B2B);
+const appMuted = Color(0xFF888888);
+const appFaintBorder = Color(0xFFEEEEEE);
+
+ThemeData buildAppTheme() {
+  final colorScheme = ColorScheme.fromSeed(seedColor: appInk);
+
+  return ThemeData(
+    useMaterial3: true,
+    colorScheme: colorScheme,
+    scaffoldBackgroundColor: Colors.white,
+    appBarTheme: const AppBarTheme(
+      backgroundColor: Colors.white,
+      foregroundColor: appInk,
+      elevation: 0,
+      surfaceTintColor: Colors.transparent,
+      titleTextStyle: TextStyle(fontSize: 17, color: appInk),
+    ),
+    filledButtonTheme: FilledButtonThemeData(
+      style: FilledButton.styleFrom(
+        backgroundColor: appInk,
+        foregroundColor: Colors.white,
+        disabledBackgroundColor: const Color(0xFFDDDDDD),
+        disabledForegroundColor: const Color(0xFF999999),
+        minimumSize: const Size.fromHeight(48),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(11)),
+        textStyle: const TextStyle(fontSize: 15),
+      ),
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        foregroundColor: appMuted,
+        side: const BorderSide(color: Color(0xFFDDDDDD), width: 2),
+        minimumSize: const Size.fromHeight(48),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(11)),
+        textStyle: const TextStyle(fontSize: 15),
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: appInk, width: 2),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: appInk, width: 2),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: appInk, width: 2),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: Color(0xFFE5484D), width: 2),
+      ),
+      labelStyle: const TextStyle(color: appMuted, fontSize: 12),
+      contentPadding: const EdgeInsets.all(11),
+    ),
+    cardTheme: CardThemeData(
+      color: Colors.white,
+      elevation: 0,
+      margin: EdgeInsets.zero,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(14),
+        side: const BorderSide(color: appFaintBorder, width: 2),
+      ),
+    ),
+    dividerTheme: const DividerThemeData(
+      color: appFaintBorder,
+      thickness: 2,
+      space: 1,
+    ),
+    textTheme: const TextTheme(
+      bodyMedium: TextStyle(color: appInk),
+    ),
+  );
+}

--- a/lib/core/utils/avatar_initial.dart
+++ b/lib/core/utils/avatar_initial.dart
@@ -1,0 +1,9 @@
+/// アバター表示用に名前の先頭1文字を返す。空なら「?」。
+///
+/// `String.substring(0, 1)`はUTF-16コードユニット単位の切り出しのため、
+/// サロゲートペアを使う絵文字などが名前の先頭に来ると不正な文字になる。
+/// `runes`(Unicodeコードポイント単位)から組み立てることでこれを避ける。
+String avatarInitial(String name) {
+  if (name.isEmpty) return '?';
+  return String.fromCharCode(name.runes.first);
+}

--- a/lib/core/utils/duration_format.dart
+++ b/lib/core/utils/duration_format.dart
@@ -1,0 +1,10 @@
+/// 残り秒数を「M:SS」形式の文字列にする(例: 310秒 → "5:10")。
+///
+/// UI改修モック(docs/ui-mockup-2a.html)のゲーム中画面が採用している表記。
+/// 負の値は0として扱う(既に過ぎている場合の表示用)。
+String formatCountdown(int totalSeconds) {
+  final clamped = totalSeconds < 0 ? 0 : totalSeconds;
+  final minutes = clamped ~/ 60;
+  final seconds = clamped % 60;
+  return '$minutes:${seconds.toString().padLeft(2, '0')}';
+}

--- a/lib/features/room/role_visibility.dart
+++ b/lib/features/room/role_visibility.dart
@@ -23,7 +23,10 @@ bool isRoleVisible({
   if (viewerRole == targetRole) return true;
   if (releasedAt == null) return false;
 
-  final phase = determineGamePhase(releasedAt: releasedAt, nowMillis: nowMillis);
+  final phase = determineGamePhase(
+    releasedAt: releasedAt,
+    nowMillis: nowMillis,
+  );
 
   switch (viewerRole) {
     case UserRole.demon:
@@ -96,6 +99,31 @@ Set<String> uidsToNotifyOfDemonChange({
       )
       .where((uid) => uid != myUid)
       .toSet();
+}
+
+/// 逃走者から見て、鬼の位置が可視性ディレイでまだ見えない理由の案内文。
+///
+/// [isRoleVisible]がfalseを返す状況(逃走者→鬼、鬼放出前 or
+/// fugitiveInfoDelaySec経過前)に対応するメッセージを返す。それ以外の
+/// 状況(もう見えているはず)ではnull。
+///
+/// UI改修モック(docs/ui-mockup-2a.html 2a-04)で、可視性ディレイ中に
+/// 何も表示されないと「壊れているのか仕様なのか分からない」という課題が
+/// 指摘されたための追加。
+String? fugitiveHiddenDemonReason({
+  required GamePhase phase,
+  required int? releasedAt,
+  required int fugitiveInfoDelaySec,
+  required int nowMillis,
+}) {
+  if (phase == GamePhase.beforeRelease) {
+    return '鬼の放出後、$fugitiveInfoDelaySec秒経つと表示されます';
+  }
+  if (releasedAt == null) return null;
+  final remainingMs = releasedAt + fugitiveInfoDelaySec * 1000 - nowMillis;
+  if (remainingMs <= 0) return null;
+  final remainingSec = (remainingMs / 1000).ceil();
+  return 'あと$remainingSec秒で表示されます';
 }
 
 /// 結果画面へ遷移すべきタイミングかどうかを判定する。

--- a/lib/features/room/view/caught_transition_overlay.dart
+++ b/lib/features/room/view/caught_transition_overlay.dart
@@ -58,8 +58,16 @@ class CaughtTransitionOverlay extends HookWidget {
                   const SizedBox(height: 32),
                   FilledButton(
                     style: FilledButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: theme.color,
+                      backgroundColor: Colors.transparent,
+                      foregroundColor: Colors.white,
+                      side: const BorderSide(color: Colors.white, width: 2),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 14,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(11),
+                      ),
                     ),
                     onPressed: onContinue,
                     child: const Text('鬼の画面へ'),

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -8,6 +8,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kakureru/core/theme/app_theme.dart';
 import 'package:kakureru/core/utils/avatar_initial.dart';
+import 'package:kakureru/core/utils/duration_format.dart';
 import 'package:kakureru/core/utils/local_notifications.dart';
 import 'package:kakureru/core/utils/server_time.dart';
 import 'package:kakureru/features/ble/repository/ble_proximity_calculator.dart';
@@ -376,7 +377,7 @@ class GamePage extends HookConsumerWidget {
                           Text(
                             countdownSec == null
                                 ? '計算中...'
-                                : '${countdownSec < 0 ? 0 : countdownSec}秒',
+                                : formatCountdown(countdownSec),
                             style: const TextStyle(
                               fontFamily: 'monospace',
                               fontWeight: FontWeight.w600,
@@ -899,7 +900,7 @@ class _PreReleaseBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final sec = countdownSec;
-    final label = sec == null ? '計算中...' : '${sec < 0 ? 0 : sec}秒';
+    final label = sec == null ? '計算中...' : formatCountdown(sec);
     return Container(
       width: double.infinity,
       color: const Color(0xFFFFFAF0),

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -541,11 +541,28 @@ class GamePage extends HookConsumerWidget {
                         ),
                       ),
                       if (opponentRoster.isEmpty)
-                        const Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 16),
-                          child: Text(
-                            '検知なし',
-                            style: TextStyle(color: appMuted, fontSize: 13),
+                        // チップ一覧+詳細カードが出せる状態(下記else節)と
+                        // 高さの差が大きいと、対象が検知されるたびに地図の
+                        // 表示領域が急に縮んでガタつく。検知なし時も同程度の
+                        // 高さを確保しておく(issue #29フォローアップ、
+                        // 「下に広がることを考えたUI」の指摘対応)。
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+                          child: Container(
+                            width: double.infinity,
+                            height: 200,
+                            alignment: Alignment.center,
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                color: appFaintBorder,
+                                width: 2,
+                              ),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: const Text(
+                              '検知なし',
+                              style: TextStyle(color: appMuted, fontSize: 13),
+                            ),
                           ),
                         )
                       else ...[
@@ -949,26 +966,31 @@ class _HiddenOpponentCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
+      // チップ一覧+詳細カードが出せる状態と高さの差が大きいと、可視性が
+      // 解禁されるたびに地図の表示領域が急に縮んでガタつくため、同程度の
+      // 高さ(200)を確保しておく(issue #29フォローアップ)。
+      height: 200,
       padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 10),
       decoration: BoxDecoration(
         border: Border.all(color: const Color(0xFFCCCCCC), width: 2),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
           const Opacity(
             opacity: 0.35,
-            child: Text('👹', style: TextStyle(fontSize: 22)),
+            child: Text('👹', style: TextStyle(fontSize: 32)),
           ),
-          const SizedBox(height: 4),
+          const SizedBox(height: 8),
           const Text(
             '鬼の位置はまだ見えません',
-            style: TextStyle(fontSize: 12.5, color: appMuted),
+            style: TextStyle(fontSize: 13, color: appMuted),
           ),
-          const SizedBox(height: 2),
+          const SizedBox(height: 4),
           Text(
             reason,
-            style: const TextStyle(fontSize: 10, color: Color(0xFFAAAAAA)),
+            style: const TextStyle(fontSize: 11, color: Color(0xFFAAAAAA)),
           ),
         ],
       ),

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/theme/app_theme.dart';
 import 'package:kakureru/core/utils/local_notifications.dart';
 import 'package:kakureru/core/utils/server_time.dart';
 import 'package:kakureru/features/ble/repository/ble_proximity_calculator.dart';
@@ -343,12 +344,28 @@ class GamePage extends HookConsumerWidget {
                 return Column(
                   children: [
                     Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Text(
-                        countdownSec == null
-                            ? '$countdownLabel: 計算中...'
-                            : '$countdownLabel: ${countdownSec < 0 ? 0 : countdownSec}秒',
-                        style: Theme.of(context).textTheme.headlineSmall,
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            countdownLabel,
+                            style: const TextStyle(
+                              color: appMuted,
+                              fontSize: 12,
+                            ),
+                          ),
+                          Text(
+                            countdownSec == null
+                                ? '計算中...'
+                                : '${countdownSec < 0 ? 0 : countdownSec}秒',
+                            style: const TextStyle(
+                              fontFamily: 'monospace',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 20,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                     if (locationState.permissionDenied)
@@ -356,81 +373,91 @@ class GamePage extends HookConsumerWidget {
                         padding: EdgeInsets.symmetric(horizontal: 16),
                         child: Text(
                           '位置情報の権限(常に許可)がないため、自分の位置を送信できません',
-                          style: TextStyle(color: Colors.red),
+                          style: TextStyle(color: Color(0xFFE5484D)),
                         ),
                       ),
                     // 「捕まった」(自己申告のみ)は廃止し、BLEで近接を検知できた
                     // ときだけ出す「鬼になる」に一本化した。ローディング表示・
                     // エラー処理・確定演出(CaughtTransitionOverlay)は、旧
                     // 「捕まった」ボタンのものをそのまま踏襲している。
+                    // この「鬼になる」ボタン(BLE 3m接近検知時)はissue #29の
+                    // スコープ外(2a-05相当。既存のUIのまま一切変更しないと
+                    // ユーザー確認済み)。アプリ全体のテーマ変更の影響も受け
+                    // ないよう、Flutter標準のThemeDataで局所的に上書きする。
                     if (myRole != null &&
                         canReportCaught(role: myRole, phase: phase) &&
                         bleBecomeDemonDetected)
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 4,
-                        ),
-                        child: FilledButton.icon(
-                          icon: isSubmittingCaught.value
-                              ? const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
-                              : const Icon(Icons.priority_high),
-                          label: const Text('鬼になる'),
-                          onPressed: isSubmittingCaught.value
-                              ? null
-                              : () async {
-                                  final confirmed = await showDialog<bool>(
-                                    context: context,
-                                    builder: (dialogContext) => AlertDialog(
-                                      title: const Text('鬼が近くにいます'),
-                                      content: const Text(
-                                        'BLEで鬼が至近距離(3m程度)にいることを検知しました。'
-                                        '鬼になりますか?この操作は取り消せません。',
-                                      ),
-                                      actions: [
-                                        TextButton(
-                                          onPressed: () => Navigator.of(
-                                            dialogContext,
-                                          ).pop(false),
-                                          child: const Text('キャンセル'),
-                                        ),
-                                        FilledButton(
-                                          onPressed: () => Navigator.of(
-                                            dialogContext,
-                                          ).pop(true),
-                                          child: const Text('鬼になる'),
-                                        ),
-                                      ],
+                      Theme(
+                        data: ThemeData(useMaterial3: true),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 4,
+                          ),
+                          child: FilledButton.icon(
+                            icon: isSubmittingCaught.value
+                                ? const SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
                                     ),
-                                  );
-                                  if (confirmed != true) return;
-
-                                  isSubmittingCaught.value = true;
-                                  try {
-                                    await ref
-                                        .read(roomRepositoryProvider)
-                                        .reportCaught(roomId);
-                                    showCaughtTransition.value = true;
-                                  } catch (e) {
-                                    if (context.mounted) {
-                                      ScaffoldMessenger.of(
-                                        context,
-                                      ).showSnackBar(
-                                        SnackBar(
-                                          content: Text('送信に失敗しました: $e'),
+                                  )
+                                : const Icon(Icons.priority_high),
+                            label: const Text('鬼になる'),
+                            onPressed: isSubmittingCaught.value
+                                ? null
+                                : () async {
+                                    final confirmed = await showDialog<bool>(
+                                      context: context,
+                                      builder: (dialogContext) => Theme(
+                                        data: ThemeData(useMaterial3: true),
+                                        child: AlertDialog(
+                                          title: const Text('鬼が近くにいます'),
+                                          content: const Text(
+                                            'BLEで鬼が至近距離(3m程度)にいることを検知しました。'
+                                            '鬼になりますか?この操作は取り消せません。',
+                                          ),
+                                          actions: [
+                                            TextButton(
+                                              onPressed: () => Navigator.of(
+                                                dialogContext,
+                                              ).pop(false),
+                                              child: const Text('キャンセル'),
+                                            ),
+                                            FilledButton(
+                                              onPressed: () => Navigator.of(
+                                                dialogContext,
+                                              ).pop(true),
+                                              child: const Text('鬼になる'),
+                                            ),
+                                          ],
                                         ),
-                                      );
+                                      ),
+                                    );
+                                    if (confirmed != true) return;
+
+                                    isSubmittingCaught.value = true;
+                                    try {
+                                      await ref
+                                          .read(roomRepositoryProvider)
+                                          .reportCaught(roomId);
+                                      showCaughtTransition.value = true;
+                                    } catch (e) {
+                                      if (context.mounted) {
+                                        ScaffoldMessenger.of(
+                                          context,
+                                        ).showSnackBar(
+                                          SnackBar(
+                                            content: Text('送信に失敗しました: $e'),
+                                          ),
+                                        );
+                                      }
+                                    } finally {
+                                      isSubmittingCaught.value = false;
                                     }
-                                  } finally {
-                                    isSubmittingCaught.value = false;
-                                  }
-                                },
+                                  },
+                          ),
                         ),
                       ),
                     Expanded(
@@ -685,7 +712,7 @@ class _LocationMap extends HookWidget {
     return Polygon(
       points: areaPoints,
       borderStrokeWidth: 2,
-      borderColor: Colors.blue,
+      borderColor: _selfColor,
       pattern: StrokePattern.dashed(segments: const [8, 4]),
     );
   }
@@ -703,7 +730,7 @@ class _LocationMap extends HookWidget {
   Marker _buildMarker(UserLocation location) {
     final isSelf = location.uid == myUid;
     final user = _findUser(users, location.uid);
-    final color = isSelf ? Colors.blue : _colorForRole(user?.role);
+    final color = isSelf ? _selfColor : _colorForRole(user?.role);
     final label = markerLabelFor(uid: location.uid, myUid: myUid, user: user);
 
     return Marker(
@@ -752,9 +779,14 @@ class _LocationMap extends HookWidget {
   }
 }
 
+/// 自分自身を表す色(青)。docs/ui-mockup-2a.htmlの配色ルール
+/// (赤=鬼/青=自分/緑=逃走者)に合わせている。
+const _selfColor = Color(0xFF3B82F6);
+
 // 取得できた位置を単純に色分けして表示する。地図・上下バー共通で使う。
+// role_theme.dartと同じ配色(鬼=赤/逃走者=緑)に揃える。
 Color _colorForRole(UserRole? role) {
-  return role == UserRole.demon ? Colors.red : Colors.green;
+  return role == null ? Colors.grey : roleThemeOf(role).color;
 }
 
 /// GPSピンに表示するラベルテキストを返す(issue #13)。
@@ -858,7 +890,7 @@ class _NearestOpponentVerticalIndicator extends StatelessWidget {
                             alignment: Alignment.center,
                             children: [
                               // 自分の中心線。太線+色ではっきり区別する。
-                              Container(height: 4, color: Colors.blue),
+                              Container(height: 4, color: _selfColor),
                               _buildDot(height),
                             ],
                           );
@@ -1037,7 +1069,7 @@ class _WifiRssiCompareView extends StatelessWidget {
           ),
           const Text('自分', style: TextStyle(fontSize: 12)),
           const SizedBox(width: 4),
-          _bar(comparison.selfRssi, Colors.blue),
+          _bar(comparison.selfRssi, _selfColor),
           const SizedBox(width: 12),
           Text(targetLabel, style: TextStyle(fontSize: 12, color: targetColor)),
           const SizedBox(width: 4),

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kakureru/core/theme/app_theme.dart';
+import 'package:kakureru/core/utils/avatar_initial.dart';
 import 'package:kakureru/core/utils/local_notifications.dart';
 import 'package:kakureru/core/utils/server_time.dart';
 import 'package:kakureru/features/ble/repository/ble_proximity_calculator.dart';
@@ -32,15 +33,6 @@ import 'package:kakureru/features/wifi/model/wifi_proximity_entry.dart';
 import 'package:kakureru/features/wifi/view_model/wifi_view_model.dart';
 import 'package:latlong2/latlong.dart' as latlong;
 import 'package:vibration/vibration.dart';
-
-/// Wi-Fi近接判定の表示方式。GamePage上でいつでも切り替えられる。
-enum _WifiDisplayMode {
-  /// 参加者ごとの3段階判定(近い/遠い/検知なし)。
-  levels,
-
-  /// 最も近い相手との上位3AP RSSI生データ比較。
-  rssiBars,
-}
 
 /// ゲーム中の画面。ゲーム内容自体はまだ無く、残り時間と参加者の位置表示のみ行う仮実装。
 class GamePage extends HookConsumerWidget {
@@ -227,7 +219,6 @@ class GamePage extends HookConsumerWidget {
     final nearestVerticalPosition = ref.watch(
       nearestOpponentVerticalPositionProvider(roomId),
     );
-    final wifiDisplayMode = useState(_WifiDisplayMode.levels);
     final bleDetections = ref.watch(bleViewModelProvider);
 
     // ゲーム画面からは戻れない(バックボタン・OSのスワイプ戻る等、
@@ -311,6 +302,27 @@ class GamePage extends HookConsumerWidget {
                 final visibleWifiComparisons = visibleNearestOpponentUid != null
                     ? ref.watch(topWifiComparisonsProvider(roomId))
                     : const <WifiApComparison>[];
+                final visibleVerticalPositions = ref
+                    .watch(relativeVerticalPositionsProvider(roomId))
+                    .where((position) => isVisibleToMe(position.uid))
+                    .toList();
+
+                // 逃走者から見て、可視性ディレイでまだ見えていない鬼がいるか
+                // (UI改修モック2a-04)。何も表示しないと不具合と区別が付かない
+                // ため、理由を明示するカードに切り替える。
+                final anyDemonHiddenFromMe =
+                    myRole == UserRole.fugitive &&
+                    room.users.any(
+                      (u) => u.role == UserRole.demon && !isVisibleToMe(u.id),
+                    );
+                final hiddenOpponentReason = anyDemonHiddenFromMe
+                    ? fugitiveHiddenDemonReason(
+                        phase: phase,
+                        releasedAt: room.releasedAt,
+                        fugitiveInfoDelaySec: room.setting.fugitiveInfoDelaySec,
+                        nowMillis: now,
+                      )
+                    : null;
 
                 // BLEで対象の役割の相手が至近距離(3m程度)にいるかどうか(issue #16)。
                 // 「捕まった」ボタン(常時表示・自己申告)とは別に、確実な捕捉を
@@ -343,6 +355,12 @@ class GamePage extends HookConsumerWidget {
 
                 return Column(
                   children: [
+                    // 鬼放出前、逃走者に「いまのうちに離れる」ことを促す
+                    // バナー(UI改修モック2a-04)。鬼にはこの助言は無関係
+                    // なので逃走者のみに出す。
+                    if (myRole == UserRole.fugitive &&
+                        phase == GamePhase.beforeRelease)
+                      _PreReleaseBanner(countdownSec: countdownSec),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
                       child: Row(
@@ -469,61 +487,96 @@ class GamePage extends HookConsumerWidget {
                         gameArea: room.setting.gameArea,
                       ),
                     ),
-                    // マップの下に「鬼(または逃走者)との上下関係」と「Wi-Fi近接表示」を
-                    // 横並びで置く。ゲーム中にちらっと見てすぐ分かることを優先し、
-                    // どちらも常に同時に見える位置にしている。
-                    SizedBox(
-                      height: 200,
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          _NearestOpponentVerticalIndicator(
-                            pressureState: pressureState,
-                            isCalibrated: _isCalibrated(room, myUid),
-                            position: visibleNearestVerticalPosition,
-                            opponentRole: _roleOf(
-                              room.users,
-                              visibleNearestVerticalPosition?.uid,
+                    // マップの下は「いま追う相手」1人に絞った統合カード
+                    // (アバター・上下判定・Wi-Fi距離感を1枚に。UI改修モック
+                    // 2a-03/2a-04)。以前は上下判定とWi-Fiを別ウィジェットに
+                    // 分け、Wi-Fi側もさらに3段階判定/RSSI比較をタブ切替して
+                    // いたが、切替の手間と情報の分断が見にくさにつながって
+                    // いたため、対象を1人に絞った上で常に両方同時表示する
+                    // 形に統合した(issue #29フォローアップ)。
+                    //
+                    // 逃走者から見て可視性ディレイでまだ鬼が見えていない間は、
+                    // 統合カードの代わりに理由を明示するカードを出す
+                    // (hiddenOpponentReason != null)。
+                    if (hiddenOpponentReason != null)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+                        child: _HiddenOpponentCard(
+                          reason: hiddenOpponentReason,
+                        ),
+                      )
+                    else ...[
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text(
+                              'いま追う相手',
+                              style: TextStyle(color: appMuted, fontSize: 11),
                             ),
-                          ),
-                          Expanded(
-                            child: Column(
-                              children: [
-                                SegmentedButton<_WifiDisplayMode>(
-                                  segments: const [
-                                    ButtonSegment(
-                                      value: _WifiDisplayMode.levels,
-                                      label: Text('3段階判定'),
-                                    ),
-                                    ButtonSegment(
-                                      value: _WifiDisplayMode.rssiBars,
-                                      label: Text('RSSI比較'),
-                                    ),
-                                  ],
-                                  selected: {wifiDisplayMode.value},
-                                  onSelectionChanged: (selection) =>
-                                      wifiDisplayMode.value = selection.first,
-                                ),
-                                Expanded(
-                                  child:
-                                      wifiDisplayMode.value ==
-                                          _WifiDisplayMode.levels
-                                      ? _WifiProximityLevelsView(
-                                          entries: visibleWifiEntries,
-                                          users: room.users,
-                                        )
-                                      : _WifiRssiCompareView(
-                                          comparisons: visibleWifiComparisons,
-                                          nearestUid: visibleNearestOpponentUid,
-                                          users: room.users,
-                                        ),
-                                ),
-                              ],
+                            Text(
+                              myRole == UserRole.demon
+                                  ? 'いちばん近い逃走者'
+                                  : 'いちばん近い鬼',
+                              style: const TextStyle(
+                                color: appMuted,
+                                fontSize: 10,
+                              ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
-                    ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: _NearestOpponentCard(
+                          user: visibleNearestOpponentUid == null
+                              ? null
+                              : _findUser(
+                                  room.users,
+                                  visibleNearestOpponentUid,
+                                ),
+                          pressureState: pressureState,
+                          isCalibrated: _isCalibrated(room, myUid),
+                          verticalPosition: visibleNearestVerticalPosition,
+                          wifiLevel: _levelFor(
+                            visibleWifiEntries,
+                            visibleNearestOpponentUid,
+                          ),
+                          comparisons: visibleWifiComparisons,
+                        ),
+                      ),
+                      if (visibleWifiEntries.any(
+                        (e) => e.uid != visibleNearestOpponentUid,
+                      )) ...[
+                        const SizedBox(height: 6),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: _OtherParticipantsRow(
+                            entries: visibleWifiEntries
+                                .where(
+                                  (e) => e.uid != visibleNearestOpponentUid,
+                                )
+                                .toList(),
+                            verticalPositions: visibleVerticalPositions,
+                            users: room.users,
+                          ),
+                        ),
+                      ],
+                    ],
+                    // BLEでの至近距離検知は逃走者にとって「鬼が来たら分かる」
+                    // 安心材料になるため、常時案内しておく(UI改修モック2a-04)。
+                    // モックの原文は「残り5分から有効」だが、実装ではBLEは
+                    // ゲーム中ずっと有効(時間による絞り込みは無い)ため、
+                    // 実態と合わない文言は載せない。
+                    if (myRole == UserRole.fugitive) ...[
+                      const SizedBox(height: 6),
+                      const Padding(
+                        padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
+                        child: _BleHintCard(),
+                      ),
+                    ] else
+                      const SizedBox(height: 8),
                   ],
                 );
               },
@@ -817,6 +870,16 @@ UserRole? _roleOf(List<RoomUser> users, String? uid) {
   return _findUser(users, uid)?.role;
 }
 
+/// [entries]から指定uidの3段階判定を探す。uidがnull、または該当エントリが
+/// 無ければnull(検知なし扱い)。
+ProximityLevel? _levelFor(List<WifiProximityEntry> entries, String? uid) {
+  if (uid == null) return null;
+  for (final entry in entries) {
+    if (entry.uid == uid) return entry.level;
+  }
+  return null;
+}
+
 /// 自分がキャリブレーション済みかどうか。ホストは meta/basePressure、
 /// 参加者は自分の users/{uid}/pressureOffset の有無で判定する
 /// (待機画面の判定基準と同じ)。
@@ -826,107 +889,259 @@ bool _isCalibrated(Room room, String? myUid) {
   return _findUser(room.users, myUid)?.pressureOffset != null;
 }
 
-/// 気圧センサーによる「鬼(または逃走者)との上下関係」表示。
-///
-/// 以前は参加者全員を1本のバーに重ねていたが、誰が誰か分かりにくかった
-/// ため、Wi-Fiの近接判定と同じ「最も近い対象の役割の相手」1人だけに絞った
-/// (nearestOpponentVerticalPositionProvider参照)。表示対象を揃えることで
-/// 認知負荷を下げる狙い。
-///
-/// センサー非対応・未キャリブレーション・検知なしの3状態を、実際に上下を
-/// 表示できる状態と明確に区別して案内する。
-class _NearestOpponentVerticalIndicator extends StatelessWidget {
-  const _NearestOpponentVerticalIndicator({
-    required this.pressureState,
-    required this.isCalibrated,
-    required this.position,
-    required this.opponentRole,
-  });
+/// 鬼放出前、逃走者に「いまのうちに離れる」ことを促すバナー
+/// (UI改修モック2a-04)。
+class _PreReleaseBanner extends StatelessWidget {
+  const _PreReleaseBanner({required this.countdownSec});
 
-  final PressureState pressureState;
-  final bool isCalibrated;
-  final RelativeVerticalPosition? position;
-  final UserRole? opponentRole;
-
-  static const _rangeMeters = 5.0;
-  static const _dotSize = 22.0;
-  static const _boxWidth = 88.0;
+  final int? countdownSec;
 
   @override
   Widget build(BuildContext context) {
-    final message = _statusMessage();
-
-    return SizedBox(
-      width: 120,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('上', style: TextStyle(fontWeight: FontWeight.bold)),
-            const SizedBox(height: 4),
-            Expanded(
-              child: Container(
-                width: _boxWidth,
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.grey.shade400),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: message != null
-                    ? Center(
-                        child: Padding(
-                          padding: const EdgeInsets.all(4),
-                          child: Text(
-                            message,
-                            textAlign: TextAlign.center,
-                            style: const TextStyle(fontSize: 12),
-                          ),
-                        ),
-                      )
-                    : LayoutBuilder(
-                        builder: (context, constraints) {
-                          final height = constraints.maxHeight;
-                          return Stack(
-                            alignment: Alignment.center,
-                            children: [
-                              // 自分の中心線。太線+色ではっきり区別する。
-                              Container(height: 4, color: _selfColor),
-                              _buildDot(height),
-                            ],
-                          );
-                        },
-                      ),
-              ),
+    final sec = countdownSec;
+    final label = sec == null ? '計算中...' : '${sec < 0 ? 0 : sec}秒';
+    return Container(
+      width: double.infinity,
+      color: const Color(0xFFFFFAF0),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          const Text('⏳', style: TextStyle(fontSize: 15)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '鬼の放出まで $label — いまのうちに離れる',
+              style: const TextStyle(fontSize: 11.5, color: Color(0xFF8A6A1E)),
             ),
-            const SizedBox(height: 4),
-            const Text('下', style: TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 可視性ディレイ中、逃走者に「なぜ鬼が見えないか」を明示するカード
+/// (UI改修モック2a-04)。何も表示しないと不具合と区別が付かないため、
+/// [fugitiveHiddenDemonReason]で計算した理由をそのまま出す。
+class _HiddenOpponentCard extends StatelessWidget {
+  const _HiddenOpponentCard({required this.reason});
+
+  final String reason;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 10),
+      decoration: BoxDecoration(
+        border: Border.all(color: const Color(0xFFCCCCCC), width: 2),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          const Opacity(
+            opacity: 0.35,
+            child: Text('👹', style: TextStyle(fontSize: 22)),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            '鬼の位置はまだ見えません',
+            style: TextStyle(fontSize: 12.5, color: appMuted),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            reason,
+            style: const TextStyle(fontSize: 10, color: Color(0xFFAAAAAA)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 「いま追う相手」1人ぶんの情報を、アバター・上下判定・Wi-Fi距離感を
+/// 1枚のカードにまとめて表示する(UI改修モック2a-03/2a-04)。
+///
+/// 以前は上下判定とWi-Fi(3段階判定/RSSI比較のタブ切替)を別ウィジェットに
+/// 分けていたが、
+/// 切替の手間と情報の分断が見にくさにつながっていたため、対象を
+/// 「最も近い相手」1人に絞った上で常に両方を同時表示する形に統合した。
+///
+/// センサー非対応・未キャリブレーション・検知なしの状態は、実際に
+/// 表示できる状態と明確に区別して案内する。
+class _NearestOpponentCard extends StatelessWidget {
+  const _NearestOpponentCard({
+    required this.user,
+    required this.pressureState,
+    required this.isCalibrated,
+    required this.verticalPosition,
+    required this.wifiLevel,
+    required this.comparisons,
+  });
+
+  final RoomUser? user;
+  final PressureState pressureState;
+  final bool isCalibrated;
+  final RelativeVerticalPosition? verticalPosition;
+  final ProximityLevel? wifiLevel;
+  final List<WifiApComparison> comparisons;
+
+  static const _rangeMeters = 5.0;
+  static const _dotSize = 14.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final target = user;
+    if (target == null) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          border: Border.all(color: appFaintBorder, width: 2),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: const Center(
+          child: Text(
+            '検知なし',
+            style: TextStyle(color: appMuted, fontSize: 13),
+          ),
+        ),
+      );
+    }
+
+    final color = _colorForRole(target.role);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        border: Border.all(color: appInk, width: 2),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(width: 56, child: _identitySection(target, color)),
+            const VerticalDivider(
+              width: 16,
+              color: appFaintBorder,
+              thickness: 2,
+            ),
+            SizedBox(width: 52, child: _verticalSection(color)),
+            const VerticalDivider(
+              width: 16,
+              color: appFaintBorder,
+              thickness: 2,
+            ),
+            Expanded(child: _wifiSection(color)),
           ],
         ),
       ),
     );
   }
 
+  Widget _identitySection(RoomUser target, Color color) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        CircleAvatar(
+          radius: 15,
+          backgroundColor: color,
+          child: Text(
+            avatarInitial(target.displayName),
+            style: const TextStyle(color: Colors.white, fontSize: 13),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          target.displayName,
+          style: const TextStyle(fontSize: 11),
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
+        ),
+      ],
+    );
+  }
+
+  Widget _verticalSection(Color opponentColor) {
+    final message = _verticalStatusMessage();
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text('上下', style: TextStyle(fontSize: 9.5, color: appMuted)),
+        const SizedBox(height: 3),
+        SizedBox(
+          height: 44,
+          child: message != null
+              ? Center(
+                  child: Text(
+                    message,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontSize: 8.5, color: appMuted),
+                  ),
+                )
+              : Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: const Color(0xFFDDDDDD)),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      return Stack(
+                        alignment: Alignment.center,
+                        children: [
+                          Container(height: 3, color: _selfColor),
+                          _buildDot(constraints.maxHeight, opponentColor),
+                        ],
+                      );
+                    },
+                  ),
+                ),
+        ),
+        const SizedBox(height: 3),
+        Text(
+          _verticalLabel(),
+          style: const TextStyle(fontSize: 9),
+        ),
+      ],
+    );
+  }
+
   /// 実際に上下を表示できないなら理由を返す。表示できるならnull。
-  String? _statusMessage() {
+  String? _verticalStatusMessage() {
     if (pressureState.sensorAvailability ==
         PressureSensorAvailability.unavailable) {
-      return 'この端末は非対応';
+      return '非対応';
     }
     if (pressureState.sensorAvailability ==
         PressureSensorAvailability.checking) {
-      return '確認中...';
+      return '確認中';
     }
     if (!isCalibrated) {
-      return 'キャリブレーションが必要です';
+      return '未実施';
     }
-    if (position == null) {
+    if (verticalPosition == null) {
       return '検知なし';
     }
     return null;
   }
 
-  Widget _buildDot(double height) {
-    final clamped = position!.deltaMeters.clamp(-_rangeMeters, _rangeMeters);
+  String _verticalLabel() {
+    final position = verticalPosition;
+    if (position == null) return '';
+    final meters = position.deltaMeters.abs().toStringAsFixed(0);
+    return position.deltaMeters >= 0
+        ? '+$meters'
+              'm 上'
+        : '-$meters'
+              'm 下';
+  }
+
+  Widget _buildDot(double height, Color opponentColor) {
+    final clamped = verticalPosition!.deltaMeters.clamp(
+      -_rangeMeters,
+      _rangeMeters,
+    );
     // t: 0(下端)〜1(上端)。deltaMetersが正(相手が上)ほどtが大きくなる。
     final t = (clamped + _rangeMeters) / (2 * _rangeMeters);
     final top = (height * (1 - t) - _dotSize / 2).clamp(0.0, height - _dotSize);
@@ -937,49 +1152,128 @@ class _NearestOpponentVerticalIndicator extends StatelessWidget {
         width: _dotSize,
         height: _dotSize,
         decoration: BoxDecoration(
-          color: _colorForRole(opponentRole),
+          color: opponentColor,
           shape: BoxShape.circle,
           border: Border.all(color: Colors.white, width: 2),
         ),
       ),
     );
   }
+
+  Widget _wifiSection(Color opponentColor) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text(
+          'Wi-Fi距離感',
+          style: TextStyle(fontSize: 9.5, color: appMuted),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          _wifiLevelLabel(),
+          style: TextStyle(
+            fontSize: 14,
+            color: opponentColor,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        if (comparisons.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          SizedBox(
+            height: 16,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                for (final comparison in comparisons) ...[
+                  Expanded(child: _miniBar(comparison.selfRssi, _selfColor)),
+                  const SizedBox(width: 2),
+                  Expanded(
+                    child: _miniBar(comparison.targetRssi, opponentColor),
+                  ),
+                  const SizedBox(width: 6),
+                ],
+              ],
+            ),
+          ),
+          const Text(
+            '青=自分/色=相手 のRSSI',
+            style: TextStyle(fontSize: 8, color: Color(0xFFAAAAAA)),
+          ),
+        ],
+      ],
+    );
+  }
+
+  String _wifiLevelLabel() {
+    switch (wifiLevel) {
+      case ProximityLevel.close:
+        return '近い';
+      case ProximityLevel.far:
+        return '遠い';
+      case ProximityLevel.notDetected:
+      case null:
+        return '検知なし';
+    }
+  }
+
+  Widget _miniBar(int rssi, Color color) {
+    const minRssi = -90;
+    const maxRssi = -40;
+    final ratio = ((rssi - minRssi) / (maxRssi - minRssi)).clamp(0.05, 1.0);
+    return FractionallySizedBox(
+      heightFactor: ratio,
+      alignment: Alignment.bottomCenter,
+      child: Container(color: color),
+    );
+  }
 }
 
-/// Wi-Fi近接判定 表示方式A: 参加者ごとの3段階判定。
-class _WifiProximityLevelsView extends StatelessWidget {
-  const _WifiProximityLevelsView({required this.entries, required this.users});
+/// 「いま追う相手」以外の参加者を、簡潔な一行(チップ)ずつで表示する
+/// (UI改修モック2a-03「他の人は下に一行ずつ」)。
+class _OtherParticipantsRow extends StatelessWidget {
+  const _OtherParticipantsRow({
+    required this.entries,
+    required this.verticalPositions,
+    required this.users,
+  });
 
   final List<WifiProximityEntry> entries;
+  final List<RelativeVerticalPosition> verticalPositions;
   final List<RoomUser> users;
 
   @override
   Widget build(BuildContext context) {
-    if (entries.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
-        child: Text('Wi-Fiスキャン結果を待っています...'),
-      );
-    }
-
-    return ListView(
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
       children: entries.map((entry) {
         final user = _findUser(users, entry.uid);
-        return ListTile(
-          dense: true,
-          leading: Icon(
-            Icons.circle,
-            size: 12,
-            color: _colorForRole(user?.role),
+        final vertical = _findVertical(entry.uid);
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+          decoration: BoxDecoration(
+            border: Border.all(color: const Color(0xFFDDDDDD), width: 1.5),
+            borderRadius: BorderRadius.circular(8),
           ),
-          title: Text(user?.displayName ?? entry.uid),
-          trailing: Text(_labelFor(entry.level)),
+          child: Text(
+            '${user?.displayName ?? entry.uid} ${_levelLabel(entry.level)}'
+            '${_arrow(vertical)}',
+            style: const TextStyle(fontSize: 10.5, color: appMuted),
+          ),
         );
       }).toList(),
     );
   }
 
-  String _labelFor(ProximityLevel level) {
+  RelativeVerticalPosition? _findVertical(String uid) {
+    for (final position in verticalPositions) {
+      if (position.uid == uid) return position;
+    }
+    return null;
+  }
+
+  String _levelLabel(ProximityLevel level) {
     switch (level) {
       case ProximityLevel.close:
         return '近い';
@@ -989,98 +1283,38 @@ class _WifiProximityLevelsView extends StatelessWidget {
         return '検知なし';
     }
   }
+
+  String _arrow(RelativeVerticalPosition? position) {
+    if (position == null) return '';
+    return position.deltaMeters >= 0 ? ' ↑' : ' ↓';
+  }
 }
 
-/// Wi-Fi近接判定 表示方式B: 判定を経由しない生RSSIバー比較。
-///
-/// 比較対象は最も近い「対象の役割」の相手(nearestOpponentUidProvider)。
-/// 共通APのうち自分・相手のRSSI平均が強い上位3つを、それぞれ自分の
-/// バーと相手のバーを並べて表示する(数値そのものは出さず、長さで見せる)。
-class _WifiRssiCompareView extends StatelessWidget {
-  const _WifiRssiCompareView({
-    required this.comparisons,
-    required this.nearestUid,
-    required this.users,
-  });
-
-  final List<WifiApComparison> comparisons;
-  final String? nearestUid;
-  final List<RoomUser> users;
-
-  static const _minRssi = -90;
-  static const _maxRssi = -40;
-  static const _maxBarWidth = 100.0;
-  static const _circledNumbers = ['①', '②', '③'];
+/// BLEでの至近距離検知についての案内(UI改修モック2a-04)。
+class _BleHintCard extends StatelessWidget {
+  const _BleHintCard();
 
   @override
   Widget build(BuildContext context) {
-    final targetUid = nearestUid;
-    if (targetUid == null) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
-        child: Text('比較対象が見つかりません(検知なし)'),
-      );
-    }
-
-    final targetUser = _findUser(users, targetUid);
-    final targetColor = _colorForRole(targetUser?.role);
-    final targetLabel = targetUser?.role == UserRole.demon ? '鬼' : '逃走者';
-
-    if (comparisons.isEmpty) {
-      return Padding(
-        padding: const EdgeInsets.all(16),
-        child: Text('${targetUser?.displayName ?? targetLabel} との共通APがまだありません'),
-      );
-    }
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF7F7F5),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: const Row(
         children: [
-          Text(
-            '比較対象: ${targetUser?.displayName ?? targetLabel}($targetLabel)',
-            style: TextStyle(color: targetColor, fontWeight: FontWeight.bold),
+          Text('📡', style: TextStyle(fontSize: 13)),
+          SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'BLEで3m以内に鬼が来ると通知されます',
+              style: TextStyle(fontSize: 10.5, color: appMuted),
+            ),
           ),
-          const SizedBox(height: 8),
-          for (var i = 0; i < comparisons.length; i++)
-            _buildApRow(i, comparisons[i], targetLabel, targetColor),
         ],
       ),
     );
-  }
-
-  Widget _buildApRow(
-    int index,
-    WifiApComparison comparison,
-    String targetLabel,
-    Color targetColor,
-  ) {
-    final number = index < _circledNumbers.length
-        ? _circledNumbers[index]
-        : '${index + 1}';
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 48,
-            child: Text('Wi-Fi$number', style: const TextStyle(fontSize: 12)),
-          ),
-          const Text('自分', style: TextStyle(fontSize: 12)),
-          const SizedBox(width: 4),
-          _bar(comparison.selfRssi, _selfColor),
-          const SizedBox(width: 12),
-          Text(targetLabel, style: TextStyle(fontSize: 12, color: targetColor)),
-          const SizedBox(width: 4),
-          _bar(comparison.targetRssi, targetColor),
-        ],
-      ),
-    );
-  }
-
-  Widget _bar(int rssi, Color color) {
-    final ratio = ((rssi - _minRssi) / (_maxRssi - _minRssi)).clamp(0.0, 1.0);
-    return Container(width: _maxBarWidth * ratio + 4, height: 10, color: color);
   }
 }

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -57,6 +57,21 @@ class GamePage extends HookConsumerWidget {
     final headerRole = _roleOf(room?.users ?? const [], myUid);
     final headerRoleTheme = headerRole != null ? roleThemeOf(headerRole) : null;
 
+    // タイマー表示はAppBar(ヘッダー)側でも使うため、body内(roomAsync.when)
+    // より前のここで計算しておく。UI改修モックはヘッダーの帯1本に役割文言と
+    // タイマーを同居させているため(2a-03/2a-04)、AppBarのtitleにこの値を渡す。
+    final now = serverNowMillis(offset);
+    final phase = determineGamePhase(
+      releasedAt: room?.releasedAt,
+      nowMillis: now,
+    );
+    final countdownSec = calculateCountdownSeconds(
+      phase: phase,
+      releasedAt: room?.releasedAt,
+      endsAt: room?.endsAt,
+      nowMillis: now,
+    );
+
     // 残り時間を1秒ごとに再計算するためのティッカー。
     // .info/serverTimeOffset 自体はズレが変化した時にしか流れてこないため、
     // 表示を毎秒更新するにはこのタイマーで再描画をトリガーする必要がある。
@@ -73,6 +88,11 @@ class GamePage extends HookConsumerWidget {
     // 成功したら全画面演出(CaughtTransitionOverlay)を出す。
     final isSubmittingCaught = useState(false);
     final showCaughtTransition = useState(false);
+
+    // 詳細カードで選択中の相手(UI改修モック2a-03「逃走者を選んで詳細を見る」)。
+    // nullの間は既定で最も近い相手を選ぶ(下のeffectiveSelectedUid参照)。
+    // ウィジェット内で完結する一時状態なのでhooksで持つ(AGENTS.md規約)。
+    final selectedOpponentUid = useState<String?>(null);
 
     // ゲーム画面に入ったら位置送信・購読を開始し、離れたら止める。
     useEffect(() {
@@ -217,9 +237,6 @@ class GamePage extends HookConsumerWidget {
     });
 
     final pressureState = ref.watch(pressureViewModelProvider);
-    final nearestVerticalPosition = ref.watch(
-      nearestOpponentVerticalPositionProvider(roomId),
-    );
     final bleDetections = ref.watch(bleViewModelProvider);
 
     // ゲーム画面からは戻れない(バックボタン・OSのスワイプ戻る等、
@@ -230,48 +247,44 @@ class GamePage extends HookConsumerWidget {
       child: Stack(
         children: [
           Scaffold(
+            // UI改修モック(2a-03/2a-04)はヘッダーの帯1本に役割文言と
+            // タイマーを左右に並べて同居させている。以前はAppBarのtitleに
+            // 役割文言だけを出し、タイマーは本文側の別行に分けていたが、
+            // 本文側は毎秒rebuildされるため、そのつどAppBarのtitleだけ
+            // 文言色が上書きされない不具合が起きていた経緯もあり、ここで
+            // 1つのRowにまとめて明示的に色を指定する。
             appBar: AppBar(
               automaticallyImplyLeading: false,
               backgroundColor: headerRoleTheme?.color,
               foregroundColor: headerRoleTheme != null ? Colors.white : null,
-              // アプリ全体の共通テーマ(app_theme.dart)がAppBarTheme.titleTextStyleに
-              // 明示的な色(appInk)を設定しているため、上のforegroundColorだけでは
-              // タイトル文字色が上書きされない(titleTextStyleの色が優先される)。
-              // ここでタイトル自体にも明示的に白を指定して勝たせる。
-              titleTextStyle: headerRoleTheme != null
-                  ? const TextStyle(
-                      color: Colors.white,
-                      fontSize: 17,
-                      fontWeight: FontWeight.w500,
-                    )
-                  : null,
-              title: Text(headerRoleTheme?.label ?? 'ゲーム中'),
-              actions: headerRoleTheme != null
-                  ? [
-                      Padding(
-                        padding: const EdgeInsets.only(right: 16),
-                        child: Icon(headerRoleTheme.icon),
+              title: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    headerRoleTheme?.label ?? 'ゲーム中',
+                    style: const TextStyle(color: Colors.white, fontSize: 15),
+                  ),
+                  if (headerRoleTheme != null)
+                    Text(
+                      countdownSec == null
+                          ? '--:--'
+                          : formatCountdown(countdownSec),
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontFamily: 'monospace',
+                        fontWeight: FontWeight.w700,
+                        fontSize: 19,
                       ),
-                    ]
-                  : null,
+                    ),
+                ],
+              ),
             ),
             body: roomAsync.when(
               data: (room) {
-                final now = serverNowMillis(offset);
+                // now/phase/countdownSecはヘッダー(AppBar)側でも使うため
+                // build()の上のほうで計算済み。ここではroomがnon-nullに
+                // 確定した状態でそのまま使い回す。
                 final myRole = _roleOf(room.users, myUid);
-                final phase = determineGamePhase(
-                  releasedAt: room.releasedAt,
-                  nowMillis: now,
-                );
-                final countdownSec = calculateCountdownSeconds(
-                  phase: phase,
-                  releasedAt: room.releasedAt,
-                  endsAt: room.endsAt,
-                  nowMillis: now,
-                );
-                final countdownLabel = phase == GamePhase.beforeRelease
-                    ? '鬼放出まで'
-                    : '残り時間';
 
                 // 役割による表示制御(7/13のプレイテストで決まった非対称な可視性)。
                 // 自分は常に見える。相手は同role同士なら常に、異roleなら
@@ -294,11 +307,6 @@ class GamePage extends HookConsumerWidget {
                 final visibleLocations = locationState.locations
                     .where((location) => isVisibleToMe(location.uid))
                     .toList();
-                final visibleNearestVerticalPosition =
-                    nearestVerticalPosition != null &&
-                        isVisibleToMe(nearestVerticalPosition.uid)
-                    ? nearestVerticalPosition
-                    : null;
                 final visibleWifiEntries = ref
                     .watch(wifiProximityLevelsProvider(roomId))
                     .where((entry) => isVisibleToMe(entry.uid))
@@ -311,9 +319,6 @@ class GamePage extends HookConsumerWidget {
                         isVisibleToMe(rawNearestOpponentUid)
                     ? rawNearestOpponentUid
                     : null;
-                final visibleWifiComparisons = visibleNearestOpponentUid != null
-                    ? ref.watch(topWifiComparisonsProvider(roomId))
-                    : const <WifiApComparison>[];
                 final visibleVerticalPositions = ref
                     .watch(relativeVerticalPositionsProvider(roomId))
                     .where((position) => isVisibleToMe(position.uid))
@@ -336,21 +341,24 @@ class GamePage extends HookConsumerWidget {
                       )
                     : null;
 
+                // 「対象の役割」(自分と逆の役割)。BLEの至近距離検知と、
+                // 下の相手選択チップの両方で使う。
+                final opponentRole = myRole == UserRole.demon
+                    ? UserRole.fugitive
+                    : UserRole.demon;
+
                 // BLEで対象の役割の相手が至近距離(3m程度)にいるかどうか(issue #16)。
                 // 「捕まった」ボタン(常時表示・自己申告)とは別に、確実な捕捉を
                 // 支援するためのボタンを検知時だけ追加で出す。isVisibleToMeで
                 // 絞るのは、他の近接表示(Wi-Fi・気圧)と同じく「鬼タイム」中は
                 // 逃走者から鬼の至近距離情報も見せない、という既存の非対称な
                 // 可視性ルール(role_visibility.dart)をBLEにも適用するため。
-                final opponentRoleForBle = myRole == UserRole.demon
-                    ? UserRole.fugitive
-                    : UserRole.demon;
                 final opponentShortUids = myRole == null
                     ? const <String>{}
                     : room.users
                           .where(
                             (u) =>
-                                u.role == opponentRoleForBle &&
+                                u.role == opponentRole &&
                                 u.id != myUid &&
                                 isVisibleToMe(u.id),
                           )
@@ -365,6 +373,38 @@ class GamePage extends HookConsumerWidget {
                   nowMillis: DateTime.now().millisecondsSinceEpoch,
                 );
 
+                // 相手選択チップの一覧(UI改修モック2a-03「逃走者を選んで詳細を
+                // 見る」)。Wi-Fiスキャン結果がまだ無い相手(visibleWifiEntries
+                // には現れない)も「検知なし」として一覧には出す必要があるため、
+                // room.usersを起点に絞り込む(visibleWifiEntriesを起点にすると
+                // スキャン未着の相手が一覧から消えてしまう)。
+                final opponentRoster = myRole == null
+                    ? const <RoomUser>[]
+                    : room.users
+                          .where(
+                            (u) =>
+                                u.role == opponentRole &&
+                                u.id != myUid &&
+                                isVisibleToMe(u.id),
+                          )
+                          .toList();
+                final rosterUids = opponentRoster.map((u) => u.id).toSet();
+                // 選択中のuidがまだ一覧に残っていればそれを使い、無ければ
+                // (未選択・退室・可視性が外れた等)既定で最も近い相手に戻す。
+                final effectiveSelectedUid =
+                    selectedOpponentUid.value != null &&
+                        rosterUids.contains(selectedOpponentUid.value)
+                    ? selectedOpponentUid.value
+                    : visibleNearestOpponentUid;
+                final selectedComparisons = effectiveSelectedUid != null
+                    ? ref.watch(
+                        wifiComparisonsForProvider((
+                          roomId,
+                          effectiveSelectedUid,
+                        )),
+                      )
+                    : const <WifiApComparison>[];
+
                 return Column(
                   children: [
                     // 鬼放出前、逃走者に「いまのうちに離れる」ことを促す
@@ -373,31 +413,6 @@ class GamePage extends HookConsumerWidget {
                     if (myRole == UserRole.fugitive &&
                         phase == GamePhase.beforeRelease)
                       _PreReleaseBanner(countdownSec: countdownSec),
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            countdownLabel,
-                            style: const TextStyle(
-                              color: appMuted,
-                              fontSize: 12,
-                            ),
-                          ),
-                          Text(
-                            countdownSec == null
-                                ? '計算中...'
-                                : formatCountdown(countdownSec),
-                            style: const TextStyle(
-                              fontFamily: 'monospace',
-                              fontWeight: FontWeight.w600,
-                              fontSize: 20,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
                     if (locationState.permissionDenied)
                       const Padding(
                         padding: EdgeInsets.symmetric(horizontal: 16),
@@ -499,17 +514,15 @@ class GamePage extends HookConsumerWidget {
                         gameArea: room.setting.gameArea,
                       ),
                     ),
-                    // マップの下は「いま追う相手」1人に絞った統合カード
-                    // (アバター・上下判定・Wi-Fi距離感を1枚に。UI改修モック
-                    // 2a-03/2a-04)。以前は上下判定とWi-Fiを別ウィジェットに
-                    // 分け、Wi-Fi側もさらに3段階判定/RSSI比較をタブ切替して
-                    // いたが、切替の手間と情報の分断が見にくさにつながって
-                    // いたため、対象を1人に絞った上で常に両方同時表示する
-                    // 形に統合した(issue #29フォローアップ)。
+                    // マップの下は、対象役割の相手をタップで選べるチップ一覧と、
+                    // 選んだ1人だけの詳細カード(UI改修モック2a-03「逃走者を
+                    // 選んで詳細を見る」)。人数が増えても見やすいよう、対象を
+                    // 常に1人だけに絞って詳細(上下判定+Wi-Fi距離感)を出す
+                    // (issue #29フォローアップ)。
                     //
                     // 逃走者から見て可視性ディレイでまだ鬼が見えていない間は、
-                    // 統合カードの代わりに理由を明示するカードを出す
-                    // (hiddenOpponentReason != null)。
+                    // チップ一覧・詳細カードの代わりに理由を明示するカードを
+                    // 出す(hiddenOpponentReason != null)。
                     if (hiddenOpponentReason != null)
                       Padding(
                         padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
@@ -520,75 +533,54 @@ class GamePage extends HookConsumerWidget {
                     else ...[
                       Padding(
                         padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            const Text(
-                              'いま追う相手',
-                              style: TextStyle(color: appMuted, fontSize: 11),
-                            ),
-                            Text(
-                              myRole == UserRole.demon
-                                  ? 'いちばん近い逃走者'
-                                  : 'いちばん近い鬼',
-                              style: const TextStyle(
-                                color: appMuted,
-                                fontSize: 10,
-                              ),
-                            ),
-                          ],
+                        child: Text(
+                          opponentRole == UserRole.fugitive
+                              ? '逃走者を選んで詳細を見る'
+                              : '鬼を選んで詳細を見る',
+                          style: const TextStyle(color: appMuted, fontSize: 11),
                         ),
                       ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: _NearestOpponentCard(
-                          user: visibleNearestOpponentUid == null
-                              ? null
-                              : _findUser(
-                                  room.users,
-                                  visibleNearestOpponentUid,
-                                ),
-                          pressureState: pressureState,
-                          isCalibrated: _isCalibrated(room, myUid),
-                          verticalPosition: visibleNearestVerticalPosition,
-                          wifiLevel: _levelFor(
-                            visibleWifiEntries,
-                            visibleNearestOpponentUid,
+                      if (opponentRoster.isEmpty)
+                        const Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 16),
+                          child: Text(
+                            '検知なし',
+                            style: TextStyle(color: appMuted, fontSize: 13),
                           ),
-                          comparisons: visibleWifiComparisons,
-                        ),
-                      ),
-                      if (visibleWifiEntries.any(
-                        (e) => e.uid != visibleNearestOpponentUid,
-                      )) ...[
-                        const SizedBox(height: 6),
+                        )
+                      else ...[
                         Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 16),
-                          child: _OtherParticipantsRow(
-                            entries: visibleWifiEntries
-                                .where(
-                                  (e) => e.uid != visibleNearestOpponentUid,
-                                )
-                                .toList(),
-                            verticalPositions: visibleVerticalPositions,
-                            users: room.users,
+                          child: _OpponentSelectorChips(
+                            roster: opponentRoster,
+                            entries: visibleWifiEntries,
+                            selectedUid: effectiveSelectedUid,
+                            onSelect: (uid) => selectedOpponentUid.value = uid,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: _OpponentDetailCard(
+                            user: effectiveSelectedUid == null
+                                ? null
+                                : _findUser(room.users, effectiveSelectedUid),
+                            pressureState: pressureState,
+                            isCalibrated: _isCalibrated(room, myUid),
+                            verticalPosition: _verticalFor(
+                              visibleVerticalPositions,
+                              effectiveSelectedUid,
+                            ),
+                            wifiLevel: _levelFor(
+                              visibleWifiEntries,
+                              effectiveSelectedUid,
+                            ),
+                            comparisons: selectedComparisons,
                           ),
                         ),
                       ],
                     ],
-                    // BLEでの至近距離検知は逃走者にとって「鬼が来たら分かる」
-                    // 安心材料になるため、常時案内しておく(UI改修モック2a-04)。
-                    // モックの原文は「残り5分から有効」だが、実装ではBLEは
-                    // ゲーム中ずっと有効(時間による絞り込みは無い)ため、
-                    // 実態と合わない文言は載せない。
-                    if (myRole == UserRole.fugitive) ...[
-                      const SizedBox(height: 6),
-                      const Padding(
-                        padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
-                        child: _BleHintCard(),
-                      ),
-                    ] else
-                      const SizedBox(height: 8),
+                    const SizedBox(height: 8),
                   ],
                 );
               },
@@ -892,6 +884,19 @@ ProximityLevel? _levelFor(List<WifiProximityEntry> entries, String? uid) {
   return null;
 }
 
+/// [positions]から指定uidの気圧上下判定を探す。uidがnull、または該当が
+/// 無ければnull(検知なし扱い)。
+RelativeVerticalPosition? _verticalFor(
+  List<RelativeVerticalPosition> positions,
+  String? uid,
+) {
+  if (uid == null) return null;
+  for (final position in positions) {
+    if (position.uid == uid) return position;
+  }
+  return null;
+}
+
 /// 自分がキャリブレーション済みかどうか。ホストは meta/basePressure、
 /// 参加者は自分の users/{uid}/pressureOffset の有無で判定する
 /// (待機画面の判定基準と同じ)。
@@ -971,18 +976,117 @@ class _HiddenOpponentCard extends StatelessWidget {
   }
 }
 
-/// 「いま追う相手」1人ぶんの情報を、アバター・上下判定・Wi-Fi距離感を
-/// 1枚のカードにまとめて表示する(UI改修モック2a-03/2a-04)。
-///
-/// 以前は上下判定とWi-Fi(3段階判定/RSSI比較のタブ切替)を別ウィジェットに
-/// 分けていたが、
-/// 切替の手間と情報の分断が見にくさにつながっていたため、対象を
-/// 「最も近い相手」1人に絞った上で常に両方を同時表示する形に統合した。
+/// 対象役割の相手を選ぶチップ一覧(UI改修モック2a-03
+/// 「逃走者を選んで詳細を見る」)。タップで[_OpponentDetailCard]に出す
+/// 相手を切り替えられる。選択中の相手は本人の役割色の枠+薄い背景で
+/// 強調し、Wi-Fi判定が「検知なし」の相手は薄く表示して目立たなくする。
+class _OpponentSelectorChips extends StatelessWidget {
+  const _OpponentSelectorChips({
+    required this.roster,
+    required this.entries,
+    required this.selectedUid,
+    required this.onSelect,
+  });
+
+  final List<RoomUser> roster;
+  final List<WifiProximityEntry> entries;
+  final String? selectedUid;
+  final ValueChanged<String> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        for (var i = 0; i < roster.length; i++) ...[
+          Expanded(child: _buildChip(roster[i])),
+          if (i != roster.length - 1) const SizedBox(width: 6),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildChip(RoomUser user) {
+    final level = _levelFor(entries, user.id);
+    final color = _colorForRole(user.role);
+    final isSelected = user.id == selectedUid;
+    final isNotDetected = level == null || level == ProximityLevel.notDetected;
+
+    return Opacity(
+      opacity: isNotDetected ? 0.5 : 1.0,
+      child: GestureDetector(
+        onTap: () => onSelect(user.id),
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: isSelected ? color : Colors.transparent,
+              width: 2,
+            ),
+            borderRadius: BorderRadius.circular(10),
+            color: isSelected ? color.withValues(alpha: 0.07) : null,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircleAvatar(
+                radius: 14,
+                backgroundColor: color,
+                child: Text(
+                  avatarInitial(user.displayName),
+                  style: const TextStyle(color: Colors.white, fontSize: 12),
+                ),
+              ),
+              const SizedBox(height: 5),
+              Text(
+                user.displayName,
+                style: TextStyle(
+                  fontSize: 11.5,
+                  color: isSelected ? appInk : appMuted,
+                ),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                _levelLabel(level),
+                style: TextStyle(fontSize: 10, color: _levelColor(level)),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _levelLabel(ProximityLevel? level) {
+    switch (level) {
+      case ProximityLevel.close:
+        return '近い';
+      case ProximityLevel.far:
+        return '遠い';
+      case ProximityLevel.notDetected:
+      case null:
+        return '検知なし';
+    }
+  }
+
+  /// 近接度に応じた文字色。「近い」だけ強調色(赤)にし、それ以外は
+  /// 目立たないグレーにする(UI改修モックの強弱付けに合わせる)。
+  Color _levelColor(ProximityLevel? level) {
+    return level == ProximityLevel.close
+        ? const Color(0xFFE5484D)
+        : const Color(0xFFAAAAAA);
+  }
+}
+
+/// 選択中の相手1人ぶんの詳細(上下判定+Wi-Fi距離感)をまとめて表示する
+/// カード(UI改修モック2a-03「◯◯ の詳細」)。
 ///
 /// センサー非対応・未キャリブレーション・検知なしの状態は、実際に
 /// 表示できる状態と明確に区別して案内する。
-class _NearestOpponentCard extends StatelessWidget {
-  const _NearestOpponentCard({
+class _OpponentDetailCard extends StatelessWidget {
+  const _OpponentDetailCard({
     required this.user,
     required this.pressureState,
     required this.isCalibrated,
@@ -1024,54 +1128,39 @@ class _NearestOpponentCard extends StatelessWidget {
     final color = _colorForRole(target.role);
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
         border: Border.all(color: appInk, width: 2),
         borderRadius: BorderRadius.circular(12),
       ),
-      child: IntrinsicHeight(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            SizedBox(width: 60, child: _identitySection(target, color)),
-            const VerticalDivider(
-              width: 20,
-              color: appFaintBorder,
-              thickness: 2,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${target.displayName} の詳細',
+            style: const TextStyle(
+              fontSize: 12,
+              color: appInk,
+              fontWeight: FontWeight.w600,
             ),
-            SizedBox(width: 58, child: _verticalSection(color)),
-            const VerticalDivider(
-              width: 20,
-              color: appFaintBorder,
-              thickness: 2,
-            ),
-            Expanded(child: _wifiSection(color)),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _identitySection(RoomUser target, Color color) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        CircleAvatar(
-          radius: 18,
-          backgroundColor: color,
-          child: Text(
-            avatarInitial(target.displayName),
-            style: const TextStyle(color: Colors.white, fontSize: 15),
           ),
-        ),
-        const SizedBox(height: 6),
-        Text(
-          target.displayName,
-          style: const TextStyle(fontSize: 12),
-          overflow: TextOverflow.ellipsis,
-          maxLines: 1,
-        ),
-      ],
+          const SizedBox(height: 10),
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(width: 84, child: _verticalSection(color)),
+                const VerticalDivider(
+                  width: 20,
+                  color: appFaintBorder,
+                  thickness: 2,
+                ),
+                Expanded(child: _wifiSection(color)),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -1080,16 +1169,16 @@ class _NearestOpponentCard extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        const Text('上下', style: TextStyle(fontSize: 9.5, color: appMuted)),
+        const Text('上下', style: TextStyle(fontSize: 10, color: appMuted)),
         const SizedBox(height: 4),
         SizedBox(
-          height: 72,
+          height: 80,
           child: message != null
               ? Center(
                   child: Text(
                     message,
                     textAlign: TextAlign.center,
-                    style: const TextStyle(fontSize: 8.5, color: appMuted),
+                    style: const TextStyle(fontSize: 9, color: appMuted),
                   ),
                 )
               : Container(
@@ -1110,11 +1199,8 @@ class _NearestOpponentCard extends StatelessWidget {
                   ),
                 ),
         ),
-        const SizedBox(height: 3),
-        Text(
-          _verticalLabel(),
-          style: const TextStyle(fontSize: 9),
-        ),
+        const SizedBox(height: 4),
+        Text(_verticalLabel(), style: const TextStyle(fontSize: 10)),
       ],
     );
   }
@@ -1179,21 +1265,21 @@ class _NearestOpponentCard extends StatelessWidget {
       children: [
         const Text(
           'Wi-Fi距離感',
-          style: TextStyle(fontSize: 9.5, color: appMuted),
+          style: TextStyle(fontSize: 10, color: appMuted),
         ),
-        const SizedBox(height: 2),
+        const SizedBox(height: 3),
         Text(
           _wifiLevelLabel(),
           style: TextStyle(
-            fontSize: 14,
-            color: opponentColor,
+            fontSize: 16,
+            color: _wifiLevelColor(),
             fontWeight: FontWeight.w600,
           ),
         ),
         if (comparisons.isNotEmpty) ...[
-          const SizedBox(height: 4),
+          const SizedBox(height: 6),
           SizedBox(
-            height: 16,
+            height: 18,
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
@@ -1208,9 +1294,10 @@ class _NearestOpponentCard extends StatelessWidget {
               ],
             ),
           ),
+          const SizedBox(height: 2),
           const Text(
-            '青=自分/色=相手 のRSSI',
-            style: TextStyle(fontSize: 8, color: Color(0xFFAAAAAA)),
+            '青=自分 / 色=相手 のRSSI',
+            style: TextStyle(fontSize: 9, color: Color(0xFFAAAAAA)),
           ),
         ],
       ],
@@ -1229,6 +1316,20 @@ class _NearestOpponentCard extends StatelessWidget {
     }
   }
 
+  /// 「近い」だけ強調色(赤)にし、それ以外は落ち着いた色にする
+  /// (チップ一覧[_OpponentSelectorChips]と同じ強弱付け)。
+  Color _wifiLevelColor() {
+    switch (wifiLevel) {
+      case ProximityLevel.close:
+        return const Color(0xFFE5484D);
+      case ProximityLevel.far:
+        return appInk;
+      case ProximityLevel.notDetected:
+      case null:
+        return appMuted;
+    }
+  }
+
   Widget _miniBar(int rssi, Color color) {
     const minRssi = -90;
     const maxRssi = -40;
@@ -1237,96 +1338,6 @@ class _NearestOpponentCard extends StatelessWidget {
       heightFactor: ratio,
       alignment: Alignment.bottomCenter,
       child: Container(color: color),
-    );
-  }
-}
-
-/// 「いま追う相手」以外の参加者を、簡潔な一行(チップ)ずつで表示する
-/// (UI改修モック2a-03「他の人は下に一行ずつ」)。
-class _OtherParticipantsRow extends StatelessWidget {
-  const _OtherParticipantsRow({
-    required this.entries,
-    required this.verticalPositions,
-    required this.users,
-  });
-
-  final List<WifiProximityEntry> entries;
-  final List<RelativeVerticalPosition> verticalPositions;
-  final List<RoomUser> users;
-
-  @override
-  Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 6,
-      runSpacing: 6,
-      children: entries.map((entry) {
-        final user = _findUser(users, entry.uid);
-        final vertical = _findVertical(entry.uid);
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-          decoration: BoxDecoration(
-            border: Border.all(color: const Color(0xFFDDDDDD), width: 1.5),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Text(
-            '${user?.displayName ?? entry.uid} ${_levelLabel(entry.level)}'
-            '${_arrow(vertical)}',
-            style: const TextStyle(fontSize: 10.5, color: appMuted),
-          ),
-        );
-      }).toList(),
-    );
-  }
-
-  RelativeVerticalPosition? _findVertical(String uid) {
-    for (final position in verticalPositions) {
-      if (position.uid == uid) return position;
-    }
-    return null;
-  }
-
-  String _levelLabel(ProximityLevel level) {
-    switch (level) {
-      case ProximityLevel.close:
-        return '近い';
-      case ProximityLevel.far:
-        return '遠い';
-      case ProximityLevel.notDetected:
-        return '検知なし';
-    }
-  }
-
-  String _arrow(RelativeVerticalPosition? position) {
-    if (position == null) return '';
-    return position.deltaMeters >= 0 ? ' ↑' : ' ↓';
-  }
-}
-
-/// BLEでの至近距離検知についての案内(UI改修モック2a-04)。
-class _BleHintCard extends StatelessWidget {
-  const _BleHintCard();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-      decoration: BoxDecoration(
-        color: const Color(0xFFF7F7F5),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: const Row(
-        children: [
-          Text('📡', style: TextStyle(fontSize: 13)),
-          SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              'BLEで3m以内に鬼が来ると通知されます',
-              style: TextStyle(fontSize: 10.5, color: appMuted),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -234,6 +234,17 @@ class GamePage extends HookConsumerWidget {
               automaticallyImplyLeading: false,
               backgroundColor: headerRoleTheme?.color,
               foregroundColor: headerRoleTheme != null ? Colors.white : null,
+              // アプリ全体の共通テーマ(app_theme.dart)がAppBarTheme.titleTextStyleに
+              // 明示的な色(appInk)を設定しているため、上のforegroundColorだけでは
+              // タイトル文字色が上書きされない(titleTextStyleの色が優先される)。
+              // ここでタイトル自体にも明示的に白を指定して勝たせる。
+              titleTextStyle: headerRoleTheme != null
+                  ? const TextStyle(
+                      color: Colors.white,
+                      fontSize: 17,
+                      fontWeight: FontWeight.w500,
+                    )
+                  : null,
               title: Text(headerRoleTheme?.label ?? 'ゲーム中'),
               actions: headerRoleTheme != null
                   ? [
@@ -1013,7 +1024,7 @@ class _NearestOpponentCard extends StatelessWidget {
     final color = _colorForRole(target.role);
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(10),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         border: Border.all(color: appInk, width: 2),
         borderRadius: BorderRadius.circular(12),
@@ -1022,15 +1033,15 @@ class _NearestOpponentCard extends StatelessWidget {
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SizedBox(width: 56, child: _identitySection(target, color)),
+            SizedBox(width: 60, child: _identitySection(target, color)),
             const VerticalDivider(
-              width: 16,
+              width: 20,
               color: appFaintBorder,
               thickness: 2,
             ),
-            SizedBox(width: 52, child: _verticalSection(color)),
+            SizedBox(width: 58, child: _verticalSection(color)),
             const VerticalDivider(
-              width: 16,
+              width: 20,
               color: appFaintBorder,
               thickness: 2,
             ),
@@ -1046,17 +1057,17 @@ class _NearestOpponentCard extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         CircleAvatar(
-          radius: 15,
+          radius: 18,
           backgroundColor: color,
           child: Text(
             avatarInitial(target.displayName),
-            style: const TextStyle(color: Colors.white, fontSize: 13),
+            style: const TextStyle(color: Colors.white, fontSize: 15),
           ),
         ),
-        const SizedBox(height: 4),
+        const SizedBox(height: 6),
         Text(
           target.displayName,
-          style: const TextStyle(fontSize: 11),
+          style: const TextStyle(fontSize: 12),
           overflow: TextOverflow.ellipsis,
           maxLines: 1,
         ),
@@ -1070,9 +1081,9 @@ class _NearestOpponentCard extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         const Text('上下', style: TextStyle(fontSize: 9.5, color: appMuted)),
-        const SizedBox(height: 3),
+        const SizedBox(height: 4),
         SizedBox(
-          height: 44,
+          height: 72,
           child: message != null
               ? Center(
                   child: Text(

--- a/lib/features/room/view/game_result_page.dart
+++ b/lib/features/room/view/game_result_page.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:kakureru/core/theme/app_theme.dart';
+import 'package:kakureru/core/utils/avatar_initial.dart';
+
+const _demonColor = Color(0xFFE5484D);
 
 /// ゲーム終了を伝える仮の画面。勝敗表示等は未実装で、鬼になった人の一覧と
 /// ホームに戻る導線のみ持つ。
@@ -12,20 +16,69 @@ class GameResultPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('ゲーム終了')),
-      body: Center(
+      body: SafeArea(
         child: Column(
-          mainAxisSize: MainAxisSize.min,
           children: [
-            const Text('ゲーム終了', style: TextStyle(fontSize: 24)),
-            const SizedBox(height: 16),
-            Text(
-              demonNames.isEmpty ? '鬼: 不明' : '鬼だった人: ${demonNames.join('、')}',
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+              decoration: const BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(color: appFaintBorder, width: 2),
+                ),
+              ),
+              child: const Text('ゲーム終了', style: TextStyle(fontSize: 20)),
             ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: () => Navigator.of(context).popUntil((route) => route.isFirst),
-              child: const Text('ホームに戻る'),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  const Text(
+                    '鬼だった人',
+                    style: TextStyle(color: appMuted, fontSize: 11),
+                  ),
+                  const SizedBox(height: 8),
+                  if (demonNames.isEmpty)
+                    const Text('不明', style: TextStyle(color: appMuted)),
+                  for (final name in demonNames)
+                    Container(
+                      margin: const EdgeInsets.only(bottom: 8),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 11,
+                        vertical: 9,
+                      ),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: appFaintBorder, width: 2),
+                        borderRadius: BorderRadius.circular(11),
+                      ),
+                      child: Row(
+                        children: [
+                          CircleAvatar(
+                            radius: 14,
+                            backgroundColor: _demonColor,
+                            child: Text(
+                              avatarInitial(name),
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 9),
+                          Text(name, style: const TextStyle(fontSize: 13.5)),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: FilledButton(
+                onPressed: () =>
+                    Navigator.of(context).popUntil((route) => route.isFirst),
+                child: const Text('ホームに戻る'),
+              ),
             ),
           ],
         ),

--- a/lib/features/room/view/room_home_page.dart
+++ b/lib/features/room/view/room_home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/theme/app_theme.dart';
 import 'package:kakureru/features/room/player_name_validation.dart';
 import 'package:kakureru/features/room/view/room_waiting_page.dart';
 import 'package:kakureru/features/room/view_model/room_view_model.dart';
@@ -65,48 +66,87 @@ class RoomHomePage extends HookConsumerWidget {
                 errorText: _nameErrorMessage(showNameError),
               ),
             ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: state.isLoading
-                  ? null
-                  : () {
-                      if (nameError != null) {
-                        hasAttemptedSubmit.value = true;
-                        return;
-                      }
-                      ref
-                          .read(roomViewModelProvider.notifier)
-                          .createRoom(nameController.text);
-                    },
-              child: const Text('ルームを作る'),
-            ),
-            const Divider(height: 48),
-            TextField(
-              controller: codeController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: 'ルームコード(4桁)'),
+            const SizedBox(height: 20),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                border: Border.all(color: appFaintBorder, width: 2),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'ホストとして',
+                    style: TextStyle(fontSize: 12, color: appMuted),
+                  ),
+                  const SizedBox(height: 8),
+                  FilledButton(
+                    onPressed: state.isLoading
+                        ? null
+                        : () {
+                            if (nameError != null) {
+                              hasAttemptedSubmit.value = true;
+                              return;
+                            }
+                            ref
+                                .read(roomViewModelProvider.notifier)
+                                .createRoom(nameController.text);
+                          },
+                    child: const Text('ルームを作る'),
+                  ),
+                ],
+              ),
             ),
             const SizedBox(height: 16),
-            OutlinedButton(
-              onPressed: state.isLoading
-                  ? null
-                  : () {
-                      if (nameError != null) {
-                        hasAttemptedSubmit.value = true;
-                        return;
-                      }
-                      ref
-                          .read(roomViewModelProvider.notifier)
-                          .joinRoom(codeController.text, nameController.text);
-                    },
-              child: const Text('ルームに参加'),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                border: Border.all(color: appFaintBorder, width: 2),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'ルームコードで参加',
+                    style: TextStyle(fontSize: 12, color: appMuted),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: codeController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(labelText: 'ルームコード(4桁)'),
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: state.isLoading
+                        ? null
+                        : () {
+                            if (nameError != null) {
+                              hasAttemptedSubmit.value = true;
+                              return;
+                            }
+                            ref
+                                .read(roomViewModelProvider.notifier)
+                                .joinRoom(
+                                  codeController.text,
+                                  nameController.text,
+                                );
+                          },
+                    child: const Text('ルームに参加'),
+                  ),
+                ],
+              ),
             ),
             if (state.hasError)
               Padding(
                 padding: const EdgeInsets.only(top: 24),
                 child: Text(
                   '${state.error}',
-                  style: const TextStyle(color: Colors.red),
+                  style: const TextStyle(color: Color(0xFFE5484D)),
                 ),
               ),
           ],

--- a/lib/features/room/view/room_waiting_page.dart
+++ b/lib/features/room/view/room_waiting_page.dart
@@ -5,6 +5,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/theme/app_theme.dart';
+import 'package:kakureru/core/utils/avatar_initial.dart';
 import 'package:kakureru/features/pressure/model/pressure_sensor_availability.dart';
 import 'package:kakureru/features/pressure/view_model/pressure_view_model.dart';
 import 'package:kakureru/features/room/calibration_status.dart';
@@ -15,6 +17,10 @@ import 'package:kakureru/features/room/single_flight_action.dart';
 import 'package:kakureru/features/room/view/game_page.dart';
 import 'package:kakureru/features/room/view/room_setting_page.dart';
 import 'package:kakureru/features/room/view_model/room_view_model.dart';
+
+const _demonColor = Color(0xFFE5484D);
+const _doneColor = Color(0xFF3A8A4A);
+const _pendingColor = Color(0xFFC88A1E);
 
 class RoomWaitingPage extends HookConsumerWidget {
   final String roomId;
@@ -134,10 +140,34 @@ class RoomWaitingPage extends HookConsumerWidget {
           return Column(
             children: [
               Padding(
-                padding: const EdgeInsets.all(24),
-                child: Text(
-                  'ルームコード: ${room.roomCode}',
-                  style: Theme.of(context).textTheme.headlineMedium,
+                padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
+                child: Row(
+                  children: [
+                    const Text(
+                      'ルームコード',
+                      style: TextStyle(color: appMuted, fontSize: 12),
+                    ),
+                    const SizedBox(width: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: appInk, width: 2),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        room.roomCode,
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                          letterSpacing: 3,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
               if (isHost && room.status == RoomStatus.waiting)
@@ -157,19 +187,26 @@ class RoomWaitingPage extends HookConsumerWidget {
                   ),
                 ),
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 4,
+                ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    const Text('参加者'),
+                    Text(
+                      '参加者 ${room.users.length}人',
+                      style: const TextStyle(color: appMuted, fontSize: 12),
+                    ),
                     if (requiredCount > 0)
                       Text(
                         'キャリブレーション $doneCount/$requiredCount人 完了',
                         style: TextStyle(
                           color: doneCount == requiredCount
-                              ? Colors.green
-                              : Colors.orange,
-                          fontWeight: FontWeight.bold,
+                              ? _doneColor
+                              : _pendingColor,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 12,
                         ),
                       ),
                   ],
@@ -177,33 +214,85 @@ class RoomWaitingPage extends HookConsumerWidget {
               ),
               Expanded(
                 child: ListView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 4,
+                  ),
                   children: room.users.map((u) {
                     final status =
                         calibrationStatuses[u.id] ?? CalibrationStatus.pending;
                     final isPending =
                         room.pendingDemonUid == u.id &&
                         u.role != UserRole.demon;
+                    final avatarColor = u.role == UserRole.demon
+                        ? _demonColor
+                        : _doneColor;
+                    final borderColor = u.role == UserRole.demon
+                        ? _demonColor
+                        : status == CalibrationStatus.pending
+                        ? _pendingColor
+                        : appFaintBorder;
+                    final subtitleColor = u.role == UserRole.demon
+                        ? _demonColor
+                        : status == CalibrationStatus.pending
+                        ? _pendingColor
+                        : appMuted;
 
-                    return ListTile(
-                      title: Text(u.displayName),
-                      subtitle: Text(
-                        u.role == UserRole.demon
-                            ? '鬼'
-                            : isPending
-                            ? '逃走者(鬼に指名中...)'
-                            : '逃走者',
-                        style: TextStyle(
-                          color: u.role == UserRole.demon ? Colors.red : null,
-                        ),
+                    return Container(
+                      margin: const EdgeInsets.only(bottom: 8),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 8,
                       ),
-                      trailing: Row(
-                        mainAxisSize: MainAxisSize.min,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: borderColor, width: 2),
+                        borderRadius: BorderRadius.circular(11),
+                        color: u.role == UserRole.demon
+                            ? _demonColor.withValues(alpha: 0.05)
+                            : status == CalibrationStatus.pending
+                            ? const Color(0xFFFFFAF0)
+                            : null,
+                      ),
+                      child: Row(
                         children: [
-                          if (u.isHost)
-                            const Padding(
-                              padding: EdgeInsets.only(right: 8),
-                              child: Text('ホスト'),
+                          CircleAvatar(
+                            radius: 13,
+                            backgroundColor: avatarColor,
+                            child: Text(
+                              avatarInitial(u.displayName),
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                              ),
                             ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  u.displayName,
+                                  style: const TextStyle(fontSize: 13),
+                                ),
+                                Text(
+                                  [
+                                    if (u.role == UserRole.demon)
+                                      '鬼'
+                                    else if (isPending)
+                                      '逃走者(鬼に指名中...)'
+                                    else
+                                      '逃走者',
+                                    if (u.isHost) 'ホスト',
+                                  ].join(' ・ '),
+                                  style: TextStyle(
+                                    color: subtitleColor,
+                                    fontSize: 9.5,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
                           _CalibrationStatusIcon(status: status),
                           if (isHost && u.role != UserRole.demon)
                             Padding(
@@ -277,7 +366,7 @@ class RoomWaitingPage extends HookConsumerWidget {
                   padding: EdgeInsets.symmetric(horizontal: 24),
                   child: Text(
                     'プレイエリアが未設定です。「設定」からエリアを指定してください',
-                    style: TextStyle(color: Colors.orange),
+                    style: TextStyle(color: _pendingColor),
                   ),
                 ),
               if (isHost && !allCalibrated && pendingNames.isNotEmpty)
@@ -285,7 +374,7 @@ class RoomWaitingPage extends HookConsumerWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 24),
                   child: Text(
                     'キャリブレーション未完了: ${pendingNames.join('、')}',
-                    style: const TextStyle(color: Colors.orange),
+                    style: const TextStyle(color: _pendingColor),
                   ),
                 ),
               if (isHost)
@@ -318,7 +407,7 @@ class RoomWaitingPage extends HookConsumerWidget {
                   padding: const EdgeInsets.only(bottom: 16),
                   child: Text(
                     '${startError.value}',
-                    style: const TextStyle(color: Colors.red),
+                    style: const TextStyle(color: _demonColor),
                   ),
                 ),
             ],
@@ -350,13 +439,17 @@ class _CalibrationStatusIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (status) {
       case CalibrationStatus.done:
-        return const Icon(Icons.check_circle, color: Colors.green);
+        return const Icon(Icons.check_circle, color: _doneColor, size: 18);
       case CalibrationStatus.pending:
-        return const Icon(Icons.radio_button_unchecked, color: Colors.orange);
+        return const Icon(
+          Icons.radio_button_unchecked,
+          color: _pendingColor,
+          size: 18,
+        );
       case CalibrationStatus.unavailable:
         return Tooltip(
           message: '気圧センサー非対応',
-          child: Icon(Icons.sensors_off, color: Colors.grey.shade400),
+          child: Icon(Icons.sensors_off, color: Colors.grey.shade400, size: 18),
         );
     }
   }
@@ -392,12 +485,12 @@ class _CalibrationSection extends ConsumerWidget {
         PressureSensorAvailability.unavailable) {
       return const Row(
         children: [
-          Icon(Icons.sensors_off, color: Colors.grey),
+          Icon(Icons.sensors_off, color: appMuted),
           SizedBox(width: 8),
           Expanded(
             child: Text(
               'この端末は気圧センサーに非対応です(キャリブレーション不要)',
-              style: TextStyle(color: Colors.grey),
+              style: TextStyle(color: appMuted, fontSize: 12),
             ),
           ),
         ],
@@ -407,11 +500,11 @@ class _CalibrationSection extends ConsumerWidget {
     if (myCalibrated) {
       return const Row(
         children: [
-          Icon(Icons.check_circle, color: Colors.green),
+          Icon(Icons.check_circle, color: _doneColor),
           SizedBox(width: 8),
           Text(
             'キャリブレーション完了',
-            style: TextStyle(color: Colors.green, fontWeight: FontWeight.bold),
+            style: TextStyle(color: _doneColor, fontWeight: FontWeight.w600),
           ),
         ],
       );
@@ -452,7 +545,13 @@ class _CalibrationSection extends ConsumerWidget {
           label: const Text('キャリブレーションする(未実施)'),
         ),
         if (hint != null)
-          Padding(padding: const EdgeInsets.only(top: 4), child: Text(hint)),
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              hint,
+              style: const TextStyle(color: appMuted, fontSize: 12),
+            ),
+          ),
       ],
     );
   }

--- a/lib/features/wifi/view_model/wifi_view_model.dart
+++ b/lib/features/wifi/view_model/wifi_view_model.dart
@@ -127,8 +127,8 @@ final _rawNearestOpponentUidProvider = Provider.family<String?, String>((
 ///
 /// [_rawNearestOpponentUidProvider]と同じ理由(Wi-Fiスキャンのノイズ)で、
 /// 直近で見つかっていた相手は[proximityHysteresisGraceDuration]の間、
-/// 保持してからnullに切り替える。この値はRSSI比較表示(topWifiComparisonsProvider)
-/// と気圧の上下判定(nearestOpponentVerticalPositionProvider)の両方が
+/// 保持してからnullに切り替える。この値は詳細カードの既定選択対象と
+/// 気圧の上下判定(nearestOpponentVerticalPositionProvider)の両方が
 /// 経由するため、ここで平滑化すればどちらの表示も一緒に安定する。
 class NearestOpponentUidNotifier extends Notifier<String?> {
   NearestOpponentUidNotifier(this.roomId);
@@ -163,16 +163,22 @@ final nearestOpponentUidProvider =
       NearestOpponentUidNotifier.new,
     );
 
-/// 表示方式B用: 最も近い相手との上位3AP比較データ。
-final topWifiComparisonsProvider =
-    Provider.family<List<WifiApComparison>, String>((ref, roomId) {
-      final nearestUid = ref.watch(nearestOpponentUidProvider(roomId));
-      if (nearestUid == null) return const [];
-
+/// 指定した相手との上位3AP比較データ(表示方式B)。
+///
+/// ゲーム画面の詳細カードは「いま選んでいる相手」(既定は最も近い相手だが
+/// タップで任意の相手に切り替えられる。UI改修モック2a-03「逃走者を選んで
+/// 詳細を見る」)の比較データを必要とするため、最も近い相手専用だった
+/// 旧`topWifiComparisonsProvider`を任意uid対応に一般化した。
+final wifiComparisonsForProvider =
+    Provider.family<List<WifiApComparison>, (String roomId, String targetUid)>((
+      ref,
+      args,
+    ) {
+      final (roomId, targetUid) = args;
       final myUid = FirebaseAuth.instance.currentUser?.uid;
       final locations = ref.watch(locationViewModelProvider).locations;
       final selfScan = _scanFor(locations, myUid);
-      final targetScan = _scanFor(locations, nearestUid);
+      final targetScan = _scanFor(locations, targetUid);
       if (selfScan == null || targetScan == null) return const [];
 
       return selectTopCommonAccessPoints(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/theme/app_theme.dart';
 import 'package:kakureru/core/utils/local_notifications.dart';
 import 'package:kakureru/features/location/view_model/location_view_model.dart';
 import 'package:kakureru/features/room/view/room_home_page.dart';
@@ -40,6 +41,6 @@ class MyApp extends HookConsumerWidget {
       return null;
     }, const []);
 
-    return const MaterialApp(home: RoomHomePage());
+    return MaterialApp(theme: buildAppTheme(), home: const RoomHomePage());
   }
 }

--- a/test/core/utils/avatar_initial_test.dart
+++ b/test/core/utils/avatar_initial_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kakureru/core/utils/avatar_initial.dart';
+
+void main() {
+  group('avatarInitial', () {
+    test('空文字なら「?」を返す', () {
+      expect(avatarInitial(''), '?');
+    });
+
+    test('通常の文字列なら先頭1文字を返す', () {
+      expect(avatarInitial('りんや'), 'り');
+    });
+
+    test('ASCII文字列なら先頭1文字を返す', () {
+      expect(avatarInitial('Alice'), 'A');
+    });
+
+    test('サロゲートペアの絵文字が先頭でも1コードポイントを正しく切り出す', () {
+      // 😀(U+1F600)はUTF-16ではサロゲートペア(2コードユニット)になるため、
+      // String.substring(0, 1)だと不正な文字(前半のみ)になってしまう対象。
+      const emojiName = '😀たろう';
+      expect(avatarInitial(emojiName), '😀');
+    });
+  });
+}

--- a/test/core/utils/duration_format_test.dart
+++ b/test/core/utils/duration_format_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kakureru/core/utils/duration_format.dart';
+
+void main() {
+  group('formatCountdown', () {
+    test('分:秒(2桁ゼロ埋め)の形式にする', () {
+      expect(formatCountdown(310), '5:10');
+    });
+
+    test('秒が1桁のときは0埋めする', () {
+      expect(formatCountdown(65), '1:05');
+    });
+
+    test('1分未満は0:SS', () {
+      expect(formatCountdown(9), '0:09');
+    });
+
+    test('0はそのまま0:00', () {
+      expect(formatCountdown(0), '0:00');
+    });
+
+    test('負の値は0:00にクランプする(既に過ぎている場合の表示用)', () {
+      expect(formatCountdown(-5), '0:00');
+    });
+
+    test('10分を超えても分側はそのまま桁数が伸びる', () {
+      expect(formatCountdown(892), '14:52');
+    });
+  });
+}

--- a/test/features/room/role_visibility_test.dart
+++ b/test/features/room/role_visibility_test.dart
@@ -316,4 +316,46 @@ void main() {
       expect(result, isEmpty);
     });
   });
+
+  group('fugitiveHiddenDemonReason', () {
+    test('鬼放出前は、放出後の待ち時間を案内する', () {
+      final reason = fugitiveHiddenDemonReason(
+        phase: GamePhase.beforeRelease,
+        releasedAt: 100000,
+        fugitiveInfoDelaySec: 30,
+        nowMillis: 0,
+      );
+      expect(reason, '鬼の放出後、30秒経つと表示されます');
+    });
+
+    test('放出後・ディレイ経過前は、残り秒数を案内する', () {
+      final reason = fugitiveHiddenDemonReason(
+        phase: GamePhase.released,
+        releasedAt: 100000,
+        fugitiveInfoDelaySec: 30,
+        nowMillis: 110000, // releasedAtから10秒経過
+      );
+      expect(reason, 'あと20秒で表示されます');
+    });
+
+    test('ディレイ経過後はnull(もう見えているはず)', () {
+      final reason = fugitiveHiddenDemonReason(
+        phase: GamePhase.released,
+        releasedAt: 100000,
+        fugitiveInfoDelaySec: 30,
+        nowMillis: 200000,
+      );
+      expect(reason, isNull);
+    });
+
+    test('releasedAtが未確定ならnull', () {
+      final reason = fugitiveHiddenDemonReason(
+        phase: GamePhase.released,
+        releasedAt: null,
+        fugitiveInfoDelaySec: 30,
+        nowMillis: 0,
+      );
+      expect(reason, isNull);
+    });
+  });
 }


### PR DESCRIPTION
## 概要
docs/ui-mockup-2a.html のトーン(色: 赤=鬼/青=自分/緑=逃走者、角丸、余白、フォント)に、以下7画面を合わせた。情報構造・機能・ボタン配置・画面遷移の挙動は変更していない(純粋な見た目の修正)。

- ホーム(2a-01)
- 待機(2a-02)
- ゲーム中・鬼(2a-03)
- ゲーム中・逃走者(2a-04)
- 鬼になった直後(2a-06)
- 結果(2a-08)
- ゲーム中画面内の地図ピン・上下インジケータ・Wi-Fi比較の配色統一(2a-03/04関連)

## 実装内容
- `lib/core/theme/app_theme.dart` (新規): アプリ全体の共通`ThemeData`(白背景・#2b2b2bの黒枠・角丸10〜16・グレー補助テキスト)を定義し、`main.dart`の`MaterialApp`に適用。
- `room_home_page.dart`: 「ホストとして」「ルームコードで参加」を角丸ボーダーのグループにまとめた。バリデーション・送信ロジックは変更なし。
- `room_waiting_page.dart`: 参加者リストを役割色(鬼=赤/完了=緑/未完了=amber)で縁取りしたカード風の行に変更。ルームコード表示をモノスペースの角丸バッジに。
- `game_page.dart`: 地図ピン・上下インジケータ・Wi-Fi比較バーの色を 鬼=#E5484D / 逃走者=#4A9C5D / 自分=#3B82F6 に統一。
- `caught_transition_overlay.dart`: 「鬼の画面へ」ボタンを透明背景+白枠のスタイルに(型はFilledButtonのまま維持し既存テストと互換)。
- `game_result_page.dart`: 鬼だった人のリストを角丸カード+丸アバターに変更。
- `lib/core/utils/avatar_initial.dart` (新規): アバターの頭文字表示で`String.substring(0,1)`によるサロゲートペア(絵文字等)の表示崩れを避けるためのユーティリティ。テストは `test/core/utils/avatar_initial_test.dart`。

## スコープ外・未対応(重要)
- **2a-05(BLE 3m接近→「鬼になる」ボタン画面)は今回のスタイリング対象外**。`game_page.dart`内の該当ボタン・確認ダイアログは`Theme(data: ThemeData(useMaterial3: true), ...)`でローカルに包み、アプリ全体テーマの影響を受けないようにして意図的に見た目を変更していない。
- **エリア外警告(2a-07)は未対応**。現在のコードベースに「プレイエリア外を検知して警告する」機能自体が存在しない(point-in-polygon判定・振動・方向表示のいずれも無い)。新規に機能を作るのは「見た目のみ」というissueのスコープを超えるため、今回は対応していない。別issueでの検討を推奨。
- 結果画面の「勝敗」「捕まった時刻」の追加(モックの改善案)は情報構造の変更にあたるため、今回は実装していない。

## テスト
- 新規ユーティリティ`avatarInitial`に単体テストを追加(`test/core/utils/avatar_initial_test.dart`)。
- **注記**: 実行環境(night-run用サンドボックス)で`/opt/flutter`がroot所有・書き込み不可になっており(`night-run/docker/Dockerfile`が`/opt/flutter`を`runner`ユーザーにchownしていない既存のインフラ不具合)、`flutter test`/`flutter analyze`を直接実行できなかった。代わりに`dart analyze lib`(flutter analyzeと同じアナライザ)と`dart format`を実行し、originmainベースラインと比較して新規のerror/warningが無いことを確認済み(ベースライン200件/exit 2 → 変更後201件/exit 2、差分は全てinfoレベル)。既存widgetテストとの整合性(`test/widget_test.dart`, `test/features/room/view/caught_transition_overlay_test.dart`等)は目視で確認し、型の不整合を1件修正済み。CI/レビュー環境で`flutter test`の実行を推奨する。

## レビュー
reviewerサブエージェントによる3ラウンドのレビューを実施し、最終的にLGTM。

Closes https://github.com/kajiLabTeam/kakureru/issues/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: 03/04の情報構造をモックに揃える(フォローアップコミット)

上記の初回実装は「見た目のみ」に絞ったが、ユーザーから「03,04の画面がちょっと違う気がする」との指摘を受け、`docs/ui-mockup-2a.html`の2a-03/2a-04と突き合わせたところ、情報構造そのもの(タブ切替UIの有無、可視性ディレイ中の理由表示の有無)が違うことを確認した。

`ui-mockup-reference`スキルの方針(情報構造の変更は依頼と無関係なら混ぜない)に従い、機能面の再構成を含めるかどうかをユーザーに再確認し、含める合意を得たうえで実装した。

### 変更内容
- **03(鬼視点)**: 上下判定とWi-Fi(3段階判定/RSSI比較のタブ切替)を別ウィジェットに分けていたのを、「いま追う相手」1人に絞った1枚のカード(`_NearestOpponentCard`)に統合。タブ切替を廃止し、アバター・上下バー・Wi-Fi距離感+RSSIミニバーを常に同時表示する。追う相手以外の参加者は`_OtherParticipantsRow`で簡潔な一行チップ表示にした。
- **04(逃走者視点)**:
  - 可視性ディレイ中「なぜ鬼が見えないか」を明示する`_HiddenOpponentCard`を追加。理由文言は`role_visibility.dart`に新設した純粋関数`fugitiveHiddenDemonReason`で計算(ユニットテスト4件追加)。
  - 鬼放出前に「いまのうちに離れる」ことを促す`_PreReleaseBanner`を追加。
  - BLE至近距離検知の案内カード(`_BleHintCard`)を追加。**モック原文の「残り5分から有効」は実装(BLEはゲーム中ずっと有効で、時間による絞り込みは無い)と食い違うため、実態に合わせて文言を調整した**(誤った案内を出さないため)。

### テスト
- `flutter test`: 全192件パス
- `flutter analyze`: エラー0件(既存のinfoレベルlintのみ)
- ※実機での視覚確認は、別途調査中の「ルーム作成が固まる」不具合(このPRの変更とは無関係、`room_repository.dart`の既存コード起因)によりまだ行えていない。復旧後に実機確認を推奨する。


---

## 追記2: 残り時間の表示形式をモック通りに(フォローアップコミット)

「◯◯秒」のみの表示だったのを、`docs/ui-mockup-2a.html`(2a-03/2a-04ヘッダー)が採用している`5:10`のような「分:秒」形式に合わせた(`formatCountdown`関数を`lib/core/utils/duration_format.dart`に切り出し、ユニットテスト6件を追加)。ゲーム中の残り時間表示・鬼放出前バナーの両方に反映した。

`flutter test`: 全198件パス。`flutter analyze`: エラー0件。


---

## 追記3: ヘッダー文字色・「いま追う相手」カードの高さ調整(フォローアップコミット)

実機確認でのフィードバックを反映。

- **「あなたは 鬼/逃走者」の文字が白くならない不具合を修正**。`app_theme.dart`の`AppBarTheme.titleTextStyle`が明示的な色(`appInk`)を持つため、`GamePage`側の`foregroundColor: Colors.white`だけではタイトル文字色が上書きされていなかった。`GamePage`のAppBarに`titleTextStyle`を明示指定して解決。
- **「いま追う相手」カードが窮屈だった**ため、外側パディング・上下バーの高さ・アバターサイズを拡大し、モックに近い見た目の余白にした。

`flutter test`: 全198件パス。`flutter analyze`: エラー0件。


---

## 追記4: 「相手を選んで詳細を見る」方式に作り直し(フォローアップコミット)

「全然デザインみたいな感じになってない」というフィードバックを受けてHTMLを読み直したところ、**`docs/ui-mockup-2a.html`自体がgitにコミットされていない状態で更新されていた**ことが判明した(2a-03の情報構造が「最も近い相手1人に固定」から「相手をタップで選ぶチップ一覧+選んだ1人の詳細カード」に変わっていた)。まずこのモックファイル自体の差分を別コミットで取り込み、それに合わせて実装をゼロから作り直した。

### 変更内容
- **ヘッダーを1本の帯に統合**。役割文言とタイマー(`5:10`のような分:秒表記)を同じ色付きAppBarに左右で並べる形にした(以前はAppBarのtitleと本文側の別行に分かれていて、モックの一体感のあるヘッダーと乖離していた)
- **「いま追う相手」1人固定のカードを廃止**し、`_OpponentSelectorChips`(対象役割の相手をタップで選べるチップ一覧。検知なしの相手は薄く表示、選択中は本人の役割色で強調)+ `_OpponentDetailCard`(選んだ1人だけの上下判定+Wi-Fi距離感。アバター列を無くした分、上下バーを大きく取れるようにした)に置き換えた
- 選択状態はhooksのローカル状態(`selectedOpponentUid`)で持ち、選択中の相手が見えなくなったら自動的に最も近い相手に戻す
- `wifi_view_model.dart`の`topWifiComparisonsProvider`(最も近い相手専用)を、任意uidを指定できる`wifiComparisonsForProvider`に一般化した
- 「その他参加者」の一行チップ表示・BLE案内カードは、更新後のモックに存在しなくなったため削除した

`flutter test`: 全198件パス。`flutter analyze`: エラー0件。


---

## 追記5: 検知なし/可視性ディレイ中の下部パネルの高さを修正(フォローアップコミット)

実機フルスクリーンで確認したところ、対象の相手が検知されていない間は下部パネルがテキスト数行だけになり、地図がほぼ画面全体を占めてしまっていた(チップ一覧+詳細カードが出せる通常時との高さの差が大きく、検知状態が切り替わるたびに地図の表示領域が急に伸縮してガタつく)。検知なし・可視性ディレイ中のどちらも高さ200を確保し、通常時と近い高さになるようにした。

`flutter test`: 全198件パス。`flutter analyze`: エラー0件。
