### PR TITLE
fix: 鬼/逃走者0人時の人数検証を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Android 9 以降、`WifiManager.startScan()` は **2分間に4回**（実質30�
 - [docs/glossary.md](docs/glossary.md) — 用語集（ユビキタス言語）。コード上の型名・enum値はここに揃える
 - [docs/scenarios.md](docs/scenarios.md) — 集合からゲーム終了までのシナリオ（SVOC分解）
 - [docs/rtdb-schema.md](docs/rtdb-schema.md) — Realtime Database のデータ構造
+- `history/` — 作業ごとの知見の記録（日報形式）。仕様の正本ではないので、実装の根拠には使わない
 
 ## Getting Started
 

--- a/history/2026-09-07-pr35-人数検証の機械検証.md
+++ b/history/2026-09-07-pr35-人数検証の機械検証.md
@@ -1,0 +1,65 @@
+# 2026-09-07 PR #35（issue #33 鬼/逃走者0人時の人数検証）の機械検証と仕上げ
+
+## やったこと
+
+night-run が作った draft PR #35 を、人間がマージ判断できる状態にした。
+
+- `flutter analyze` / `flutter test` を実行した。**このブランチのコードは一度もコンパイルされていなかった**
+  （night-run のサンドボックスが `pub.dev` / `storage.googleapis.com` / `dl.google.com` を遮断していて
+  Flutter ツールチェイン自体が動かなかったため）。
+- 唯一出た新規指摘（`test/features/room/role_visibility_test.dart` の `avoid_redundant_argument_values`）を解消した。
+  `isGameOver` の `hasFugitives` は既定値 `true` なので、テストで `hasFugitives: true` を明示すると lint に当たる。
+  引数を落として意図をコメントに移した。
+- `game_page.dart` の終了判定 `useEffect` の依存配列に逃走者人数が入っていない点を検証し、**変更不要**と結論した（根拠は下記）。
+- 実装担当とは別のレビュー担当エージェントに `main` との全差分をレビューさせ、**合格（86点）** を得た。
+
+結果: `flutter test` 205件全通過（main の 198件 + 7件）、`flutter analyze` は 296件で
+**ベースラインと完全に同一**（info 292 + 既存 warning 4 + error 0、追加行に新規指摘なし）。
+
+## 詰まった点 / 解決方法
+
+**`flutter analyze` のベースラインを取り違えた。**
+`flutter analyze` の出力は重大度ラベルが右揃えになるため、`warning` 行は `info` 行より字下げが浅く、
+行頭から始まる。`grep -E '^\s+(error|warning|info) '` のように「1文字以上の空白」を要求すると
+**warning 行だけが集計から漏れる**。当初「292件すべて info」と記録してしまい、実装担当の再実測で訂正された。
+正しいベースラインは **296件 = info 292 + warning 4 + error 0**。
+warning 4件はすべて既存の `inference_failure_on_instance_creation`（`MaterialPageRoute` の型引数）。
+
+教訓: 件数だけでなく**指摘の集合そのものがベースラインと一致するか**で判定する方が確実。
+`flutter analyze` の合計は末尾の "N issues found" を見る。
+
+**依存配列の検証を、憶測で済ませずソースまで追った。**
+`isGameOver` に新しく渡している `hasFugitives:` の変化は `useEffect` の依存配列に入っていない。
+「`tick` が毎秒更新するから拾えるはず」で終わらせず、flutter_hooks 側まで確認した:
+
+1. `game_page.dart` の `tick` は `Timer.periodic(const Duration(seconds: 1))` で毎秒インクリメントされる
+   （依存配列 `const []` なのでタイマーはマウント時に1回だけ作られる）
+2. flutter_hooks は `Hook.shouldPreserveState` で `keys` を要素ごとに `!=` 比較し、
+   変化していれば古い `HookState` を破棄して `initHook()` を呼び直す → effect 本体が再実行される
+3. 再実行される本体は**その build で新しく作られたクロージャ**なので、`ref.watch` 由来の最新の `room` を読む
+
+したがって逃走者0人は**最大1秒遅れで必ず拾われ、取りこぼしは起きない**。コード変更なし。
+
+## 次回への申し送り・知見
+
+**このリポジトリで widget テストが書けない構造的な理由**（レビューでも同じ結論）:
+`game_page.dart` / `room_waiting_page.dart` / `room_setting_page.dart` は `build()` 直下で
+`FirebaseAuth.instance.currentUser?.uid` を直接読んでいる。provider を経由していないので
+`ProviderScope(overrides:)` では差し替えられず、`Firebase.initializeApp()` していないテストでは
+その行で `[core/no-app]` 例外になる。**uid を Riverpod provider 経由にする seam が入るまで、
+この3画面の widget テストは書けない。**
+`lib/core/providers/firebase_providers.dart` は初回コミットから0バイトの空ファイルで、
+まさにその provider を置く意図だけが残っている。
+
+**そのため、今回の純関数テストは「ロジック」しか守っていない。**
+`hasStartableRoleComposition` は4ケース検証済みだが、それを呼ぶ側の配線
+（`game_page.dart` の `any(role == fugitive)` と、開始ボタンの `onPressed` 無効化）は無検証。
+述語を `demon` と書き間違えても全テストが通る。**seam が入ったら配線のテストを足すこと。**
+
+**レビューが挙げた follow-up（このPRのスコープ外）**:
+- 最後に捕まった本人の端末だけ、結果画面へ自動遷移しない。`showCaughtTransition` の演出ガードが
+  「鬼の画面へ」のタップまで下りないため。ゲームを終わらせた当人が手動タップを要求される
+- RTDB に `FINISHED` が書かれない。`finishRoom()` は lib 内に呼び出し元が1つも無く、
+  終了検知は全端末クライアント側のみ。`endsAt` 経過による既存の終了も同じ設計なのでこのPRの回帰ではない
+- **単独プレイでの実機確認ができなくなった。** ホスト1人の部屋は、逃走者なら鬼0人で不可、
+  鬼なら逃走者0人で不可。どちらの構成でも開始できない。実機確認は2端末が前提になる

--- a/lib/features/room/role_visibility.dart
+++ b/lib/features/room/role_visibility.dart
@@ -128,13 +128,31 @@ String? fugitiveHiddenDemonReason({
 
 /// 結果画面へ遷移すべきタイミングかどうかを判定する。
 ///
-/// meta/status が FINISHED になった場合、または endsAt を過ぎた場合に真。
+/// meta/status が FINISHED になった場合、endsAt を過ぎた場合、または
+/// ゲーム進行中(PLAYING)に逃走者が0人(全員鬼)になった場合に真。
+/// 逃走者0人での終了は「ゲームが始まった後」だけ意味を持つため、
+/// PLAYING時のみ判定する(WAITING中はまだ誰も逃走者を割り当てていない
+/// だけなので、それを終了扱いにしない)。
 /// 端末ごとの時計のズレを避けるため、比較には絶対時刻(serverNowMillis)を使う。
 bool isGameOver({
   required RoomStatus status,
   required int? endsAt,
   required int nowMillis,
+  bool hasFugitives = true,
 }) {
   if (status == RoomStatus.finished) return true;
+  if (status == RoomStatus.playing && !hasFugitives) return true;
   return endsAt != null && nowMillis >= endsAt;
+}
+
+/// ホストが「ゲーム開始」を押せる役割構成かどうかを判定する。
+///
+/// 鬼が1人もいない、または全員鬼(逃走者が1人もいない)のいずれかだと
+/// 開始した瞬間に[isGameOver]が真になってしまい成立しないため、
+/// どちらの役割も1人以上いることを開始条件にする(issue #33)。
+bool hasStartableRoleComposition({
+  required int demonCount,
+  required int totalUserCount,
+}) {
+  return demonCount > 0 && demonCount < totalUserCount;
 }

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -177,6 +177,7 @@ class GamePage extends HookConsumerWidget {
         status: room.status,
         endsAt: room.endsAt,
         nowMillis: serverNowMillis(offset),
+        hasFugitives: room.users.any((u) => u.role == UserRole.fugitive),
       );
       if (!gameOver) return null;
       hasNavigatedToResult.value = true;

--- a/lib/features/room/view/room_waiting_page.dart
+++ b/lib/features/room/view/room_waiting_page.dart
@@ -13,6 +13,7 @@ import 'package:kakureru/features/room/calibration_status.dart';
 import 'package:kakureru/features/room/left_user_notifications.dart';
 import 'package:kakureru/features/room/model/room.dart';
 import 'package:kakureru/features/room/model/room_user.dart';
+import 'package:kakureru/features/room/role_visibility.dart';
 import 'package:kakureru/features/room/single_flight_action.dart';
 import 'package:kakureru/features/room/view/game_page.dart';
 import 'package:kakureru/features/room/view/room_setting_page.dart';
@@ -108,6 +109,13 @@ class RoomWaitingPage extends HookConsumerWidget {
           final demonCandidates = room.users
               .where((u) => u.role != UserRole.demon)
               .toList();
+          final demonCount = room.users
+              .where((u) => u.role == UserRole.demon)
+              .length;
+          final canStartWithRoleComposition = hasStartableRoleComposition(
+            demonCount: demonCount,
+            totalUserCount: room.users.length,
+          );
 
           final calibrationStatuses = {
             for (final u in room.users)
@@ -361,6 +369,22 @@ class RoomWaitingPage extends HookConsumerWidget {
                 basePressure: room.basePressure,
                 pressureState: pressureState,
               ),
+              if (isHost && demonCount == 0)
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
+                  child: Text(
+                    '鬼が1人も指名されていません。「鬼にする」または「鬼をランダムで決める」で指名してください',
+                    style: TextStyle(color: _pendingColor),
+                  ),
+                ),
+              if (isHost && demonCount > 0 && !canStartWithRoleComposition)
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
+                  child: Text(
+                    '全員が鬼になっています。逃走者が1人以上必要です',
+                    style: TextStyle(color: _pendingColor),
+                  ),
+                ),
               if (isHost && room.setting.gameArea.isEmpty)
                 const Padding(
                   padding: EdgeInsets.symmetric(horizontal: 24),
@@ -383,6 +407,7 @@ class RoomWaitingPage extends HookConsumerWidget {
                   child: FilledButton(
                     onPressed:
                         isStarting.value ||
+                            !canStartWithRoleComposition ||
                             room.setting.gameArea.isEmpty ||
                             !allCalibrated
                         ? null

--- a/test/features/room/role_visibility_test.dart
+++ b/test/features/room/role_visibility_test.dart
@@ -244,6 +244,72 @@ void main() {
         isFalse,
       );
     });
+
+    test('PLAYING中に逃走者が0人になったら、endsAt前でも終了とみなす', () {
+      expect(
+        isGameOver(
+          status: RoomStatus.playing,
+          endsAt: 60000,
+          nowMillis: 0,
+          hasFugitives: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('PLAYING中でも逃走者が残っていればhasFugitivesは終了に影響しない', () {
+      expect(
+        isGameOver(
+          status: RoomStatus.playing,
+          endsAt: 60000,
+          nowMillis: 0,
+          hasFugitives: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('WAITING中に逃走者が0人でも(まだゲーム開始前)終了とはみなさない', () {
+      expect(
+        isGameOver(
+          status: RoomStatus.waiting,
+          endsAt: null,
+          nowMillis: 0,
+          hasFugitives: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('hasStartableRoleComposition', () {
+    test('鬼が0人なら開始できない', () {
+      expect(
+        hasStartableRoleComposition(demonCount: 0, totalUserCount: 3),
+        isFalse,
+      );
+    });
+
+    test('全員鬼(逃走者が0人)なら開始できない', () {
+      expect(
+        hasStartableRoleComposition(demonCount: 3, totalUserCount: 3),
+        isFalse,
+      );
+    });
+
+    test('鬼と逃走者が両方1人以上いれば開始できる', () {
+      expect(
+        hasStartableRoleComposition(demonCount: 1, totalUserCount: 3),
+        isTrue,
+      );
+    });
+
+    test('参加者が0人なら開始できない', () {
+      expect(
+        hasStartableRoleComposition(demonCount: 0, totalUserCount: 0),
+        isFalse,
+      );
+    });
   });
 
   group('canReportCaught', () {

--- a/test/features/room/role_visibility_test.dart
+++ b/test/features/room/role_visibility_test.dart
@@ -257,14 +257,11 @@ void main() {
       );
     });
 
-    test('PLAYING中でも逃走者が残っていればhasFugitivesは終了に影響しない', () {
+    test('PLAYING中に逃走者が残っていれば終了とはみなさない', () {
+      // hasFugitivesの既定値はtrue(逃走者がいる)。既定のままなら
+      // 逃走者0人による終了判定は働かず、endsAt前は終了にならない。
       expect(
-        isGameOver(
-          status: RoomStatus.playing,
-          endsAt: 60000,
-          nowMillis: 0,
-          hasFugitives: true,
-        ),
+        isGameOver(status: RoomStatus.playing, endsAt: 60000, nowMillis: 0),
         isFalse,
       );
     });


### PR DESCRIPTION
## 概要

issue #33 の対応。以下2点を修正する。

1. 逃走者が0人(全員鬼)になってもゲームが自動終了しなかった問題
2. 鬼が1人もいない/全員鬼の状態でもホストが「ゲーム開始」ボタンを押せてしまっていた問題

## 実装内容

- `lib/features/room/role_visibility.dart`
  - `isGameOver()` に `bool hasFugitives = true`(省略可能引数、既存呼び出し元・テストとの後方互換のためデフォルトtrue)を追加。PLAYING中に逃走者が0人なら自動終了とみなす。
  - `hasStartableRoleComposition({required int demonCount, required int totalUserCount})` を新規追加。鬼0人、または全員鬼(逃走者0人)のどちらでも開始不可と判定する純粋関数(既存の `isCalibrationComplete` と同じ、テスト容易性のための切り出しパターン)。
- `lib/features/room/view/game_page.dart`: `isGameOver()` 呼び出しに `hasFugitives:` を渡す。
- `lib/features/room/view/room_waiting_page.dart`: 「ゲーム開始」ボタンの無効化条件に `hasStartableRoleComposition` の結果を追加。鬼0人時・全員鬼時それぞれに既存の「エリア未設定」「キャリブレーション未完了」と同じスタイルのヒントテキストを表示。
- `test/features/room/role_visibility_test.dart`: ユニットテスト7件を追加。既存のテストケースは変更していない。
- `history/2026-09-07-pr35-人数検証の機械検証.md`: 作業記録。README の一覧にも `history/` を登録した。

## 機械検証の結果

**当初このPRは「`flutter test` / `flutter analyze` を実行できていない」状態で作成されていた**(実行環境に Flutter ツールチェインが無かったため)。ローカルの Flutter 3.44.8 で実行し、以下を確認した。

| 項目 | main のベースライン | このブランチ |
| --- | --- | --- |
| `flutter test` | 198件 全通過 | **205件 全通過**(+7) |
| `flutter analyze` | 296 issues (info 292 + warning 4 + error 0) | **296 issues。指摘の集合がベースラインと同一** |
| `python3 scripts/verify_safety_net.py` | 27件中1件失敗(既存の壊れたリンク) | 同じ1件のみ。増えていない |

`flutter analyze` の warning 4件はいずれも main に既存の `inference_failure_on_instance_creation`(`MaterialPageRoute` の型引数)で、このPRが触った行とは無関係のため意図的に手を付けていない(別途対応)。

コンパイル時に発覚した指摘は1件のみで、`test/features/room/role_visibility_test.dart` の `avoid_redundant_argument_values` を解消した(`hasFugitives` は既定値 `true` なので、テストで明示すると lint に当たる。引数を落として意図をコメントに移した)。

### `game_page.dart` の `useEffect` 依存配列について

`isGameOver()` に新しく渡している `hasFugitives:` の変化は、`useEffect` の依存配列に入っていない。これは**意図的に変更していない**。理由:

1. `tick` が `Timer.periodic(const Duration(seconds: 1))` で毎秒インクリメントされる(依存配列 `const []` なのでタイマーはマウント時に1回だけ作られる)
2. flutter_hooks は `Hook.shouldPreserveState` で `keys` を要素ごとに比較し、変化していれば古い `HookState` を破棄して `initHook()` を呼び直す → effect 本体が再実行される
3. 再実行される本体は**その build で新しく作られたクロージャ**なので、`ref.watch` 由来の最新の `room` を読む

したがって逃走者0人は**最大1秒遅れで必ず拾われ、取りこぼしは起きない**。これはこのファイルが既にコメントで説明している「tickを依存に入れて毎秒チェックし直す」のと同じ設計。

## レビュー

実装担当とは別のレビュー担当エージェントが、main との全差分(このPRの元コミットを含む)を独立にレビューし、**合格(86点)**。5観点(要件充足 / スコープ厳守 / 不要コード / テスト / 禁止事項)すべて合格。

## テストについて

追加した7件は `isGameOver` と `hasStartableRoleComposition` の**純関数**を対象にしている。

**配線(`game_page.dart` の `any(role == fugitive)` と、開始ボタンの `onPressed` 無効化)のテストは書けていない。** 両画面が `build()` 直下で `FirebaseAuth.instance.currentUser?.uid` を直接読んでおり、`Firebase.initializeApp()` していないテスト環境では `[core/no-app]` 例外になるため。uid を Riverpod provider 経由にする seam が必要で、それは #36 が別途追加している。**#36 がマージされたら配線のテストを足せる。**

## 動作確認方法(手動)

1. ルーム待機画面で鬼を誰も指名していない状態で「ゲーム開始」ボタンが無効化され、ヒントが出ることを確認する。
2. 全員を鬼に指名した状態で同様にボタンが無効化され「全員が鬼になっています。逃走者が1人以上必要です」が出ることを確認する。
3. 鬼1人以上・逃走者1人以上でゲームを開始し、プレイ中に残りの逃走者が全員捕まって鬼になったら、自動的に結果画面へ遷移することを確認する。

## ⚠️ この変更による運用上の影響

**単独(1端末)での実機確認ができなくなった。** ホスト1人だけの部屋は、逃走者なら鬼0人で開始不可、鬼なら逃走者0人で開始不可となり、どちらの構成でも開始できない。これは修正1(逃走者0人なら即終了)と整合させるために必要な条件だが、**実機での動作確認は2端末が前提になる**。

## follow-up(このPRのスコープ外)

- **#37** — 最後に捕まった本人の端末だけ結果画面へ自動遷移しない(捕まった演出のガードがタップまで下りないため)。他の全端末は約1秒で遷移する。
- `startGame()` 側(RTDB書き込み時点)には人数検証を追加していない。既存の他の設定変更処理と同じくクライアント側ガードのみという既存アーキテクチャの前提で、issue #33 も明示的にスコープ外としているため意図的。
- RTDB に `FINISHED` が書かれない(`finishRoom()` は lib 内に呼び出し元が無く、終了検知は全端末クライアント側のみ)。`endsAt` 経過による既存の終了も同じ設計なので**このPRの回帰ではない**が、既存債務として認識しておきたい。

Closes #33