### PR TITLE
エラーハンドリングとローディング表示が欠けている箇所を修正する

### DIFF
--- a/history/2026-09-07-pr36-エラーハンドリングのテスト補完.md
+++ b/history/2026-09-07-pr36-エラーハンドリングのテスト補完.md
@@ -1,0 +1,84 @@
+# 2026-09-07 PR #36（issue #34 エラーハンドリングとローディング表示）のテスト補完
+
+## やったこと
+
+night-run が作った draft PR #36 を、人間がマージ判断できる状態にした。
+
+- `flutter analyze` / `flutter test` を実行した。**このブランチのコードは一度もコンパイルされていなかった**
+  （night-run のサンドボックスが `pub.dev` / `storage.googleapis.com` / `dl.google.com` を遮断していたため）。
+- **issue #34 の7項目のうち、テストが無かった item 1・2・3・5・6 にテストを追加した**
+  （元は item 4・7 だけがテスト済み）。「モック基盤がリポジトリに存在しない」として未完了になっていた分。
+- そのために**テスト用の seam を4つ**足した。いずれもリポジトリに既存の手本があるやり方のみを使った。
+- 実装担当とは別のレビュー担当エージェントに `main` との全差分をレビューさせ、2巡目で **合格（93点）** を得た。
+  1巡目は**スコープ違反で不合格**（下記）。
+
+結果: `flutter test` 216件全通過（main の 198件から +18）、`flutter analyze` は error 0・**新規指摘 0件**。
+
+### 足した seam
+
+| seam | 内容 | 手本にした既存コード |
+| --- | --- | --- |
+| A | `lib/core/providers/firebase_providers.dart`（0バイトの空ファイル）に uid を供給する provider を定義し、`build()` 直下の `FirebaseAuth.instance` 直参照を置き換え | Riverpod provider の既存の書き方 |
+| B | `RoomRepository` の `.instance` 解決を初期化子リストから `late final` へ | `_FakeBleScanRepository extends BleScanRepository`（`ble_view_model_test.dart`） |
+| C | `LocationTaskHandler` にコンストラクタ関数注入 | `ble_permission.dart` / `location_permission.dart` |
+| D | 「await して失敗をログに残す」処理を1関数に切り出し、Wi-Fi・気圧の両リポジトリから呼ぶ | （重複していた try/catch の統合） |
+
+## 詰まった点 / 解決方法
+
+**`RoomRepository` の fake サブクラスが作れなかった（seam B の理由）。**
+`RoomRepository({FirebaseDatabase? db, FirebaseAuth? auth}) : _db = db ?? FirebaseDatabase.instance, ...`
+という**初期化子リストでの即時評価**のため、`extends` した瞬間に暗黙の `super()` で `.instance` が走り
+`[core/no-app]` になる。`FirebaseDatabase` / `FirebaseAuth` 自体は private コンストラクタなので、
+テストダブルを引数で渡すこともできない。`.instance` の解決を `late final` にして解決した。
+**`PressureRepository` / `WifiScanRepository` / `LocationRepository` も同じ形のまま残っている。**
+
+**`flutter_map` がジェスチャーを持っていくため `tester.drag` が使えなかった（item 3）。**
+`room_setting_page.dart` の `_AreaMap` は `GestureDetector(onPanStart:...)` で `FlutterMap` を包む構造だが、
+flutter_map は `ScaleGestureRecognizer` を `if (dragEnabled)` の**外側**で無条件に登録し、
+`_gestureArenaTeam.captain` に設定する（`map_interactive_viewer.dart`）。子の recognizer なので
+gesture arena で親の pan に勝ち、`InteractiveFlag.none` にしても無効化されない。
+対照実験で `panStart=0`（子が `FlutterMap`）vs `panStart=1`（対照）を確認した。
+テストはページ側の `GestureDetector` のコールバックを直接呼ぶ形にして回避した
+（`MapCamera.screenOffsetToLatLng` と `describeGameAreaSizeError` は実物を通る）。
+**これは実機でも同じ可能性があり、issue #38 として切り出した（要実機確認）。**
+
+**`dispose` 時の `leaveRoom` が実行されていない実在のバグを見つけた（7項目外）。**
+`useEffect` のクリーンアップが `ref.read(roomRepositoryProvider)` を呼んでいたが、Riverpod 3 の
+`ConsumerStatefulElement._assertNotDisposed` はアンマウント後に**デバッグ時限定でなく常に** `StateError`
+（`Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe.`）を投げる。
+flutter_hooks がそれを捕まえてログに出すだけだったので、**戻るたびに退出処理が黙って飛ばされ、
+`users/{uid}` と `locations/{uid}` が RTDB に残っていた。** build 時に取得した `roomRepo` を使う形に修正。
+この修正なしでは待機画面の widget テスト7件が dispose 時例外で全滅するため、item 5・6 のテストに必須だった。
+
+**1巡目のレビューでスコープ違反により不合格になった。**
+main に既存だった warning 4件（`inference_failure_on_instance_creation` / `MaterialPageRoute` の型引数）を
+「ついでに」全部直していた。計画書は「既存 lint の解消はスコープ外」と明記していたし、
+特に `game_page.dart` は**lint 修正だけのために無関係なファイルを差分に持ち込んでいた**。
+人間の判断で**4件すべて差し戻し**（`git revert` 相当の前進コミットで実施。`git reset --hard` は使わない）。
+差し戻すと `game_page.dart` は差分から丸ごと消えた。この warning 修正自体は正しい内容なので別PRで出す。
+
+**`flutter analyze` の判定は「件数」ではなく「指摘の集合」で見ないと騙される。**
+スコープ外の修正で総数が 296 → 287 に**減っていた**ため、一見「新規指摘なし」に見えたが、
+集合で比較すると `test/widget_test.dart` の `type_annotate_public_apis` が2件**増えていた**。
+`git archive main` で複製して両方 `dart analyze` にかけ、`(重大度, ファイル, ルール)` で
+多重集合の差分を取るのが確実。
+なお warning 行は info 行より字下げが浅く行頭から始まるので、`grep -E '^\s+...'` では**漏れる**。
+
+## 次回への申し送り・知見
+
+- **`myUidProvider` の seam が入ったので、`GamePage` の widget テストが書けるようになった。**
+  PR #35 が「配線（`any(role == fugitive)` と開始ボタンの無効化）のテストが書けない」として
+  残した分は、このPRのマージ後に足せる。`game_page.dart` はまだ `FirebaseAuth.instance` 直参照のままなので、
+  そこも同じ provider に置き換える必要がある（今回は差分最小化のため触っていない）。
+- **item 2 のテストは切り出した関数のみが対象で、リポジトリ側の呼び出し配線はテストされていない。**
+  `WiFiScan.instance` が private コンストラクタ＋setter 無しで差し替え不能、`WiFiAccessPoint` も
+  private コンストラクタのみのため、mocktail を入れてもスキャン経路は駆動できない（だから依存追加はしていない）。
+  配線は手動確認（RTDB ルールを一時的に拒否設定にしてログを確認）に頼る。
+- **このリポジトリには `.github/workflows/` が無い＝CIが無い。** night-run が「コンパイルされていないコードを
+  PR にしてしまう」事故を防げなかった根本原因はこれ。`flutter pub get && flutter analyze && flutter test` を
+  回すだけのワークフローがあれば、この種の問題は PR の時点で止まる。
+- 「鬼をランダムで決める」（`room_waiting_page.dart`）は今も catch なし＝エラー表示がない。
+  issue #34 の item 5 は「鬼にする」「取り消す」だけが対象なので触っていないが、同じ画面に非対称が残っている。
+- `PressureRepository` / `WifiScanRepository` / `LocationRepository` は seam B と同じ
+  「初期化子リストで `.instance` を即時評価」のままで、fake サブクラスが作れない。
+  これらのテストが必要になったら同じ `late final` 化が要る。

--- a/lib/core/providers/firebase_providers.dart
+++ b/lib/core/providers/firebase_providers.dart
@@ -1,0 +1,19 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// サインイン済みの自分のuid。まだサインインしていなければnull。
+///
+/// 画面から `FirebaseAuth.instance` を直接触ると、Firebaseを初期化して
+/// いないwidgetテストでは参照した瞬間に `[core/no-app]` 例外になり、
+/// その画面のテストが一切組めなくなる(providerを経由していないので
+/// 差し替える隙間が無い)。Provider経由にしておけば
+/// `overrideWithValue` でテスト用のuidに差し替えられるため、uidの取得は
+/// ここに集約する。
+///
+/// 匿名サインインは `main()` が `runApp` の前に完了させる(main.dart参照)
+/// ため、アプリの生存期間中この値は変わらない。したがってProviderが
+/// 値をキャッシュしたままでも、毎回 `FirebaseAuth.instance` を読むのと
+/// 同じ結果になる。
+final myUidProvider = Provider<String?>(
+  (ref) => FirebaseAuth.instance.currentUser?.uid,
+);

--- a/lib/core/utils/rtdb_write.dart
+++ b/lib/core/utils/rtdb_write.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+
+/// センサー値の定期送信のように「1回失敗しても次の周期で送り直せばよいが、
+/// 黙って消えると原因調査ができない」RTDB書き込みを実行する。
+///
+/// [write] の完了を待ち、失敗しても例外を呼び出し側へ投げ返さず
+/// `[$tag] $fieldの書き込みに失敗: ...` の形でログにだけ残す。await せずに
+/// 投げっぱなしにすると、失敗は未処理の非同期エラーとしてどこにも出ずに
+/// 消えてしまうため、ここで必ず待ち合わせる。
+///
+/// Wi-Fi(`WifiScanRepository`)と気圧(`PressureRepository`)の定期送信が
+/// まったく同じ扱いを必要とするため、同じtry/catchを2箇所に書かないよう
+/// 切り出している。
+///
+/// [log] はテストから出力を検証するためだけの引数。省略すると [debugPrint]。
+Future<void> writeOrLogFailure(
+  Future<void> Function() write, {
+  required String tag,
+  required String field,
+  void Function(String message)? log,
+}) async {
+  try {
+    await write();
+  } on Object catch (e) {
+    (log ?? _logWithDebugPrint)('[$tag] $fieldの書き込みに失敗: $e');
+  }
+}
+
+void _logWithDebugPrint(String message) => debugPrint(message);

--- a/lib/features/location/repository/location_task_handler.dart
+++ b/lib/features/location/repository/location_task_handler.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:geolocator/geolocator.dart';
 
@@ -10,6 +11,11 @@ import 'package:geolocator/geolocator.dart';
 /// (`LocationRepository`)へ渡すだけにし、実際のFirebase書き込みは
 /// 従来通り動作確認済みのメインisolate側で行う。
 class LocationTaskHandler extends TaskHandler {
+  /// 直近で連続して失敗した回数。1回ごとの失敗は電波状況等で普通に起き
+  /// うるため騒がず、連続失敗が積み上がったときだけログで検知できるように
+  /// する。取得できた時点で0に戻す。
+  int _consecutiveFailures = 0;
+
   @override
   Future<void> onStart(DateTime timestamp, TaskStarter starter) async {}
 
@@ -23,13 +29,19 @@ class LocationTaskHandler extends TaskHandler {
       final position = await Geolocator.getCurrentPosition(
         locationSettings: const LocationSettings(accuracy: LocationAccuracy.high),
       );
+      _consecutiveFailures = 0;
       FlutterForegroundTask.sendDataToMain({
         'lat': position.latitude,
         'lng': position.longitude,
         'altitude': position.altitude,
       });
-    } on Object catch (_) {
+    } on Object catch (e) {
+      _consecutiveFailures++;
       // 取得失敗時は今回はスキップし、次のonRepeatEventで再試行する。
+      // ログだけは残し、連続失敗が続いていることを追えるようにする。
+      debugPrint(
+        '[LocationTaskHandler] 位置取得に失敗($_consecutiveFailures回連続): $e',
+      );
     }
   }
 

--- a/lib/features/location/repository/location_task_handler.dart
+++ b/lib/features/location/repository/location_task_handler.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:geolocator/geolocator.dart';
 
@@ -10,7 +12,32 @@ import 'package:geolocator/geolocator.dart';
 /// [FlutterForegroundTask.sendDataToMain] でメインisolate
 /// (`LocationRepository`)へ渡すだけにし、実際のFirebase書き込みは
 /// 従来通り動作確認済みのメインisolate側で行う。
+///
+/// 位置取得とログ出力はコンストラクタで差し替えられるようにしてある
+/// (テストでは実機のGPSを使わずに、連続失敗回数の数え方だけを検証するため。
+/// BlePermissionService・LocationPermissionServiceと同じ注入の形に揃えた)。
 class LocationTaskHandler extends TaskHandler {
+  /// 引数を省略すると実際のプラグイン(geolocator)と [debugPrint] を使う。
+  /// テストからのみ差し替える。
+  LocationTaskHandler({
+    Future<Position> Function()? getCurrentPosition,
+    void Function(String message)? log,
+  }) : _getCurrentPosition = getCurrentPosition ?? _getWithGeolocator,
+       _log = log ?? _logWithDebugPrint;
+
+  final Future<Position> Function() _getCurrentPosition;
+  final void Function(String message) _log;
+
+  static Future<Position> _getWithGeolocator() {
+    return Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+      ),
+    );
+  }
+
+  static void _logWithDebugPrint(String message) => debugPrint(message);
+
   /// 直近で連続して失敗した回数。1回ごとの失敗は電波状況等で普通に起き
   /// うるため騒がず、連続失敗が積み上がったときだけログで検知できるように
   /// する。取得できた時点で0に戻す。
@@ -21,14 +48,20 @@ class LocationTaskHandler extends TaskHandler {
 
   @override
   void onRepeatEvent(DateTime timestamp) {
-    _sendCurrentPosition();
+    // 1回失敗しても次の周期で再試行するだけなので完了は待たない
+    // (待つと取得にかかった時間だけ送信間隔が伸びてしまう)。
+    unawaited(sendCurrentPosition());
   }
 
-  Future<void> _sendCurrentPosition() async {
+  /// 位置を1回取得してメインisolateへ渡す。取得に失敗しても例外は投げ返さず、
+  /// 連続失敗回数を添えてログに残すだけにする(次の [onRepeatEvent] で再試行)。
+  ///
+  /// [onRepeatEvent] は完了を待たないため、失敗の数え方をテストから検証
+  /// できるようこのメソッドを公開している(テスト専用の入口)。
+  @visibleForTesting
+  Future<void> sendCurrentPosition() async {
     try {
-      final position = await Geolocator.getCurrentPosition(
-        locationSettings: const LocationSettings(accuracy: LocationAccuracy.high),
-      );
+      final position = await _getCurrentPosition();
       _consecutiveFailures = 0;
       FlutterForegroundTask.sendDataToMain({
         'lat': position.latitude,
@@ -39,9 +72,7 @@ class LocationTaskHandler extends TaskHandler {
       _consecutiveFailures++;
       // 取得失敗時は今回はスキップし、次のonRepeatEventで再試行する。
       // ログだけは残し、連続失敗が続いていることを追えるようにする。
-      debugPrint(
-        '[LocationTaskHandler] 位置取得に失敗($_consecutiveFailures回連続): $e',
-      );
+      _log('[LocationTaskHandler] 位置取得に失敗($_consecutiveFailures回連続): $e');
     }
   }
 

--- a/lib/features/pressure/repository/pressure_repository.dart
+++ b/lib/features/pressure/repository/pressure_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_database/firebase_database.dart';
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:kakureru/features/pressure/pressure_math.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 
@@ -60,10 +61,14 @@ class PressureRepository {
   /// rooms/{roomId}/locations/{uid}/pressure への定期送信を開始する。
   void startSendingToRoom(String roomId) {
     stopSendingToRoom();
-    _writeTimer = Timer.periodic(const Duration(seconds: 4), (_) {
+    _writeTimer = Timer.periodic(const Duration(seconds: 4), (_) async {
       final value = _latestSmoothed;
       if (value == null) return;
-      _db.ref('rooms/$roomId/locations/$_uid/pressure').set(value);
+      try {
+        await _db.ref('rooms/$roomId/locations/$_uid/pressure').set(value);
+      } on Object catch (e) {
+        debugPrint('[PressureRepository] pressureの書き込みに失敗: $e');
+      }
     });
   }
 

--- a/lib/features/pressure/repository/pressure_repository.dart
+++ b/lib/features/pressure/repository/pressure_repository.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_database/firebase_database.dart';
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:kakureru/core/utils/rtdb_write.dart';
 import 'package:kakureru/features/pressure/pressure_math.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 
@@ -64,11 +64,11 @@ class PressureRepository {
     _writeTimer = Timer.periodic(const Duration(seconds: 4), (_) async {
       final value = _latestSmoothed;
       if (value == null) return;
-      try {
-        await _db.ref('rooms/$roomId/locations/$_uid/pressure').set(value);
-      } on Object catch (e) {
-        debugPrint('[PressureRepository] pressureの書き込みに失敗: $e');
-      }
+      await writeOrLogFailure(
+        () => _db.ref('rooms/$roomId/locations/$_uid/pressure').set(value),
+        tag: 'PressureRepository',
+        field: 'pressure',
+      );
     });
   }
 

--- a/lib/features/room/repository/room_repository.dart
+++ b/lib/features/room/repository/room_repository.dart
@@ -7,14 +7,28 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:kakureru/features/room/model/room.dart';
 import 'package:kakureru/features/room/model/room_setting.dart';
 
+/// ルームの作成・参加・監視といったRTDB操作をまとめたリポジトリ。
 class RoomRepository {
-  final FirebaseDatabase _db;
-  final FirebaseAuth _auth;
-  final _random = Random();
-
+  /// 引数を省略すると実際のFirebase(`FirebaseDatabase.instance` /
+  /// `FirebaseAuth.instance`)を使う。テストからのみ差し替える。
   RoomRepository({FirebaseDatabase? db, FirebaseAuth? auth})
-    : _db = db ?? FirebaseDatabase.instance,
-      _auth = auth ?? FirebaseAuth.instance;
+    : _dbOverride = db,
+      _authOverride = auth;
+
+  final FirebaseDatabase? _dbOverride;
+  final FirebaseAuth? _authOverride;
+
+  // `.instance` の解決を初期化子リストではなくlateの遅延初期化にしている
+  // のは、メソッドを丸ごとoverrideするテスト用のサブクラスが、暗黙の
+  // `super()` を通るだけでFirebase未初期化の例外(`[core/no-app]`)を
+  // 踏まないようにするため(FirebaseDatabase/FirebaseAuthはコンストラクタ
+  // が非公開でテストダブルを渡せないので、サブクラスで差し替えるしかない)。
+  // 引数を渡さなければ`.instance`を使う、という外から見た振る舞いは
+  // 解決のタイミングが遅くなるだけで変わらない。
+  late final FirebaseDatabase _db = _dbOverride ?? FirebaseDatabase.instance;
+  late final FirebaseAuth _auth = _authOverride ?? FirebaseAuth.instance;
+
+  final _random = Random();
 
   String get _uid => _auth.currentUser!.uid;
 

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -185,7 +185,7 @@ class GamePage extends HookConsumerWidget {
           .map((u) => u.displayName)
           .toList();
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute<void>(
+        MaterialPageRoute(
           builder: (_) => GameResultPage(demonNames: demonNames),
         ),
       );

--- a/lib/features/room/view/game_page.dart
+++ b/lib/features/room/view/game_page.dart
@@ -185,7 +185,7 @@ class GamePage extends HookConsumerWidget {
           .map((u) => u.displayName)
           .toList();
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(
+        MaterialPageRoute<void>(
           builder: (_) => GameResultPage(demonNames: demonNames),
         ),
       );

--- a/lib/features/room/view/room_home_page.dart
+++ b/lib/features/room/view/room_home_page.dart
@@ -20,11 +20,19 @@ class RoomHomePage extends HookConsumerWidget {
     useListenable(nameController);
     final nameError = validatePlayerName(nameController.text);
 
-    // 最初から赤字を出すと圧が強いため、「作成/参加」を一度押すまでは
-    // エラー表示を出さない。押した時点で名前が無効なら、そこで初めて
-    // 表示する(以降は入力のたびに再評価されるので、直せば自動で消える)。
-    final hasAttemptedSubmit = useState(false);
-    final showNameError = hasAttemptedSubmit.value ? nameError : null;
+    // 名前が無効な間は「作成/参加」ボタン自体を無効化するため、押してから
+    // 気づかせる必要はない。ただし最初から赤字を出すと圧が強いので、
+    // 一度でも入力欄に触れた後だけエラー表示する(未入力の初期状態では
+    // 出さない)。
+    final hasTouchedName = useState(false);
+    final showNameError = hasTouchedName.value ? nameError : null;
+
+    // ルーム作成/参加は同じroomViewModelProviderを共有しているため、
+    // state.isLoadingだけでは押されたのがどちらのボタンか区別できない。
+    // ローディング表示(スピナー)を押した側だけに出すため、ローカルに
+    // どちらを押したかを持つ。
+    final isCreating = useState(false);
+    final isJoining = useState(false);
 
     // 前回保存済みの名前を、入力欄がまだ空のうちだけ初期値として復元する
     // (ユーザーが既に入力し始めていたら上書きしない)。
@@ -42,6 +50,10 @@ class RoomHomePage extends HookConsumerWidget {
     }, [savedDisplayName.asData?.value]);
 
     ref.listen(roomViewModelProvider, (prev, next) {
+      if (!next.isLoading) {
+        isCreating.value = false;
+        isJoining.value = false;
+      }
       final roomId = next.value;
       if (roomId != null) {
         Navigator.of(context).push(
@@ -61,6 +73,7 @@ class RoomHomePage extends HookConsumerWidget {
             TextField(
               controller: nameController,
               maxLength: playerNameMaxLength,
+              onChanged: (_) => hasTouchedName.value = true,
               decoration: InputDecoration(
                 labelText: '名前',
                 errorText: _nameErrorMessage(showNameError),
@@ -83,18 +96,24 @@ class RoomHomePage extends HookConsumerWidget {
                   ),
                   const SizedBox(height: 8),
                   FilledButton(
-                    onPressed: state.isLoading
+                    onPressed: state.isLoading || nameError != null
                         ? null
                         : () {
-                            if (nameError != null) {
-                              hasAttemptedSubmit.value = true;
-                              return;
-                            }
+                            isCreating.value = true;
                             ref
                                 .read(roomViewModelProvider.notifier)
                                 .createRoom(nameController.text);
                           },
-                    child: const Text('ルームを作る'),
+                    child: isCreating.value
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
+                        : const Text('ルームを作る'),
                   ),
                 ],
               ),
@@ -122,13 +141,10 @@ class RoomHomePage extends HookConsumerWidget {
                   ),
                   const SizedBox(height: 12),
                   OutlinedButton(
-                    onPressed: state.isLoading
+                    onPressed: state.isLoading || nameError != null
                         ? null
                         : () {
-                            if (nameError != null) {
-                              hasAttemptedSubmit.value = true;
-                              return;
-                            }
+                            isJoining.value = true;
                             ref
                                 .read(roomViewModelProvider.notifier)
                                 .joinRoom(
@@ -136,7 +152,13 @@ class RoomHomePage extends HookConsumerWidget {
                                   nameController.text,
                                 );
                           },
-                    child: const Text('ルームに参加'),
+                    child: isJoining.value
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('ルームに参加'),
                   ),
                 ],
               ),

--- a/lib/features/room/view/room_home_page.dart
+++ b/lib/features/room/view/room_home_page.dart
@@ -57,7 +57,7 @@ class RoomHomePage extends HookConsumerWidget {
       final roomId = next.value;
       if (roomId != null) {
         Navigator.of(context).push(
-          MaterialPageRoute(
+          MaterialPageRoute<void>(
             builder: (_) => RoomWaitingPage(roomId: roomId),
           ),
         );

--- a/lib/features/room/view/room_home_page.dart
+++ b/lib/features/room/view/room_home_page.dart
@@ -57,7 +57,7 @@ class RoomHomePage extends HookConsumerWidget {
       final roomId = next.value;
       if (roomId != null) {
         Navigator.of(context).push(
-          MaterialPageRoute<void>(
+          MaterialPageRoute(
             builder: (_) => RoomWaitingPage(roomId: roomId),
           ),
         );

--- a/lib/features/room/view/room_setting_page.dart
+++ b/lib/features/room/view/room_setting_page.dart
@@ -171,7 +171,10 @@ class RoomSettingPage extends HookConsumerWidget {
                     isDrawing: isDrawing.value,
                     dragStart: dragStart.value,
                     dragCurrent: dragCurrent.value,
+                    hasSizeError: areaSizeError.value != null,
                     onDragStart: (point) {
+                      // 新しいドラッグを始めたら前回のエラー状態はクリアする。
+                      areaSizeError.value = null;
                       dragStart.value = point;
                       dragCurrent.value = point;
                     },
@@ -179,33 +182,31 @@ class RoomSettingPage extends HookConsumerWidget {
                     onDragEnd: () {
                       final start = dragStart.value;
                       final current = dragCurrent.value;
-                      if (start != null && current != null) {
-                        // 矩形の対角線の長さでサイズを検証する。数px程度の
-                        // タップに近いドラッグ(退化した矩形)や、地図を
-                        // 世界スケールまで引いてから引いた極端に大きい矩形を
-                        // 弾く(理由はgame_map_options.dartのコメント参照)。
-                        final diagonalMeters = Geolocator.distanceBetween(
-                          start.latitude,
-                          start.longitude,
-                          current.latitude,
-                          current.longitude,
+                      if (start == null || current == null) return;
+
+                      // 矩形の対角線の長さでサイズを検証する。数px程度の
+                      // タップに近いドラッグ(退化した矩形)や、地図を
+                      // 世界スケールまで引いてから引いた極端に大きい矩形を
+                      // 弾く(理由はgame_map_options.dartのコメント参照)。
+                      final diagonalMeters = Geolocator.distanceBetween(
+                        start.latitude,
+                        start.longitude,
+                        current.latitude,
+                        current.longitude,
+                      );
+                      final error = describeGameAreaSizeError(diagonalMeters);
+                      areaSizeError.value = error;
+                      if (error == null) {
+                        gameArea.value = calculateRectangleCorners(
+                          LatLng(lat: start.latitude, lng: start.longitude),
+                          LatLng(lat: current.latitude, lng: current.longitude),
                         );
-                        final error = describeGameAreaSizeError(
-                          diagonalMeters,
-                        );
-                        areaSizeError.value = error;
-                        if (error == null) {
-                          gameArea.value = calculateRectangleCorners(
-                            LatLng(lat: start.latitude, lng: start.longitude),
-                            LatLng(
-                              lat: current.latitude,
-                              lng: current.longitude,
-                            ),
-                          );
-                        }
+                        dragStart.value = null;
+                        dragCurrent.value = null;
                       }
-                      dragStart.value = null;
-                      dragCurrent.value = null;
+                      // エラー時はリセットせず、仮矩形を赤枠のまま残して
+                      // エラーメッセージと視覚的に結びつける
+                      // (次のドラッグ開始 or 有効なドラッグで上書きされる)。
                     },
                   ),
                 ),
@@ -238,7 +239,14 @@ class RoomSettingPage extends HookConsumerWidget {
                           ),
                         ),
                       OutlinedButton(
-                        onPressed: () => isDrawing.value = !isDrawing.value,
+                        onPressed: () {
+                          isDrawing.value = !isDrawing.value;
+                          // モード切り替え時に仮矩形とエラー表示も持ち越さない
+                          // (描画をやめたのに赤枠だけ残るのを防ぐ)。
+                          dragStart.value = null;
+                          dragCurrent.value = null;
+                          areaSizeError.value = null;
+                        },
                         child: Text(
                           isDrawing.value ? '描画をやめる(地図の移動に戻す)' : 'エリアを描く',
                         ),
@@ -359,6 +367,7 @@ class _AreaMap extends HookWidget {
     required this.isDrawing,
     required this.dragStart,
     required this.dragCurrent,
+    required this.hasSizeError,
     required this.onDragStart,
     required this.onDragUpdate,
     required this.onDragEnd,
@@ -372,6 +381,11 @@ class _AreaMap extends HookWidget {
   final bool isDrawing;
   final latlong.LatLng? dragStart;
   final latlong.LatLng? dragCurrent;
+
+  /// 直近のドラッグ結果(dragStart/dragCurrent)がサイズ超過等で
+  /// 弾かれているかどうか。trueの間は仮矩形を赤枠で表示し、
+  /// 無効なままであることを視覚的に伝える。
+  final bool hasSizeError;
   final ValueChanged<latlong.LatLng> onDragStart;
   final ValueChanged<latlong.LatLng> onDragUpdate;
   final VoidCallback onDragEnd;
@@ -448,9 +462,10 @@ class _AreaMap extends HookWidget {
                       ),
                     ),
                   ),
-                  color: Colors.orange.withValues(alpha: 0.2),
+                  color: (hasSizeError ? Colors.red : Colors.orange)
+                      .withValues(alpha: 0.2),
                   borderStrokeWidth: 2,
-                  borderColor: Colors.orange,
+                  borderColor: hasSizeError ? Colors.red : Colors.orange,
                   pattern: StrokePattern.dashed(segments: const [8, 4]),
                 ),
             ],

--- a/lib/features/room/view/room_setting_page.dart
+++ b/lib/features/room/view/room_setting_page.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/providers/firebase_providers.dart';
 import 'package:kakureru/features/room/game_map_options.dart';
 import 'package:kakureru/features/room/model/room.dart';
 import 'package:kakureru/features/room/model/room_setting.dart';
@@ -31,7 +31,7 @@ class RoomSettingPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final roomAsync = ref.watch(roomStreamProvider(roomId));
     final room = roomAsync.value;
-    final myUid = FirebaseAuth.instance.currentUser?.uid;
+    final myUid = ref.watch(myUidProvider);
 
     final releaseWaitMin = useState(1);
     final gameDurationMin = useState(5);

--- a/lib/features/room/view/room_setting_page.dart
+++ b/lib/features/room/view/room_setting_page.dart
@@ -462,8 +462,9 @@ class _AreaMap extends HookWidget {
                       ),
                     ),
                   ),
-                  color: (hasSizeError ? Colors.red : Colors.orange)
-                      .withValues(alpha: 0.2),
+                  color: (hasSizeError ? Colors.red : Colors.orange).withValues(
+                    alpha: 0.2,
+                  ),
                   borderStrokeWidth: 2,
                   borderColor: hasSizeError ? Colors.red : Colors.orange,
                   pattern: StrokePattern.dashed(segments: const [8, 4]),

--- a/lib/features/room/view/room_waiting_page.dart
+++ b/lib/features/room/view/room_waiting_page.dart
@@ -35,7 +35,32 @@ class RoomWaitingPage extends HookConsumerWidget {
     final hasNavigated = useState(false);
     final isNominatingRandom = useState(false);
     final randomNominationGuard = useMemoized(SingleFlightAction.new);
+    // 「鬼にする」「取り消す」の送信中フラグ。同時に1件までしか実行しない
+    // ため、実行中の対象uidだけを持てば足りる。SingleFlightActionは
+    // リビルドを待たずに同期で多重発火を防ぐためのガード
+    // (ランダム指名ボタンと同じ理由。上のコメント参照)。
+    final demonActionUid = useState<String?>(null);
+    final demonActionError = useState<Object?>(null);
+    final demonActionGuard = useMemoized(SingleFlightAction.new);
     final myUid = FirebaseAuth.instance.currentUser?.uid;
+    final roomRepo = ref.read(roomRepositoryProvider);
+
+    Future<void> runDemonAction(
+      String uid,
+      Future<void> Function() action,
+    ) async {
+      await demonActionGuard.run(() async {
+        demonActionUid.value = uid;
+        demonActionError.value = null;
+        try {
+          await action();
+        } on Object catch (e) {
+          demonActionError.value = e;
+        } finally {
+          demonActionUid.value = null;
+        }
+      });
+    }
 
     useEffect(() {
       ref.read(pressureViewModelProvider.notifier).init(roomId);
@@ -212,6 +237,14 @@ class RoomWaitingPage extends HookConsumerWidget {
                   ],
                 ),
               ),
+              if (demonActionError.value != null)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Text(
+                    '${demonActionError.value}',
+                    style: const TextStyle(color: _demonColor),
+                  ),
+                ),
               Expanded(
                 child: ListView(
                   padding: const EdgeInsets.symmetric(
@@ -299,18 +332,50 @@ class RoomWaitingPage extends HookConsumerWidget {
                               padding: const EdgeInsets.only(left: 8),
                               child: room.pendingDemonUid == u.id
                                   ? ActionChip(
-                                      label: const Text('取り消す'),
-                                      onPressed: () => ref
-                                          .read(roomRepositoryProvider)
-                                          .cancelDemonNomination(roomId),
+                                      label: demonActionUid.value == u.id
+                                          ? const SizedBox(
+                                              width: 12,
+                                              height: 12,
+                                              child: CircularProgressIndicator(
+                                                strokeWidth: 2,
+                                              ),
+                                            )
+                                          : const Text('取り消す'),
+                                      onPressed: demonActionUid.value != null
+                                          ? null
+                                          : () => unawaited(
+                                              runDemonAction(
+                                                u.id,
+                                                () => roomRepo
+                                                    .cancelDemonNomination(
+                                                      roomId,
+                                                    ),
+                                              ),
+                                            ),
                                     )
                                   : ActionChip(
-                                      label: const Text('鬼にする'),
-                                      onPressed: room.pendingDemonUid != null
+                                      label: demonActionUid.value == u.id
+                                          ? const SizedBox(
+                                              width: 12,
+                                              height: 12,
+                                              child: CircularProgressIndicator(
+                                                strokeWidth: 2,
+                                              ),
+                                            )
+                                          : const Text('鬼にする'),
+                                      onPressed:
+                                          demonActionUid.value != null ||
+                                              room.pendingDemonUid != null
                                           ? null
-                                          : () => ref
-                                                .read(roomRepositoryProvider)
-                                                .nominateDemon(roomId, u.id),
+                                          : () => unawaited(
+                                              runDemonAction(
+                                                u.id,
+                                                () => roomRepo.nominateDemon(
+                                                  roomId,
+                                                  u.id,
+                                                ),
+                                              ),
+                                            ),
                                     ),
                             ),
                         ],
@@ -531,7 +596,16 @@ class _CalibrationSection extends ConsumerWidget {
     return Column(
       children: [
         FilledButton.icon(
-          icon: const Icon(Icons.touch_app),
+          icon: pressureState.isCalibrating
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Icon(Icons.touch_app),
           onPressed: canCalibrate
               ? () {
                   final notifier = ref.read(pressureViewModelProvider.notifier);
@@ -542,7 +616,9 @@ class _CalibrationSection extends ConsumerWidget {
                   }
                 }
               : null,
-          label: const Text('キャリブレーションする(未実施)'),
+          label: Text(
+            pressureState.isCalibrating ? 'キャリブレーション中...' : 'キャリブレーションする(未実施)',
+          ),
         ),
         if (hint != null)
           Padding(

--- a/lib/features/room/view/room_waiting_page.dart
+++ b/lib/features/room/view/room_waiting_page.dart
@@ -121,7 +121,10 @@ class RoomWaitingPage extends HookConsumerWidget {
     useEffect(() {
       return () {
         if (!hasNavigated.value) {
-          unawaited(ref.read(roomRepositoryProvider).leaveRoom(roomId));
+          // 破棄中(unmount中)はrefがもう使えず、ここでref.readすると
+          // StateErrorになってleaveRoomが呼ばれないままになる
+          // (widgetテストで発覚)。build時に取得しておいたroomRepoを使う。
+          unawaited(roomRepo.leaveRoom(roomId));
         }
       };
     }, const []);

--- a/lib/features/room/view/room_waiting_page.dart
+++ b/lib/features/room/view/room_waiting_page.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/providers/firebase_providers.dart';
 import 'package:kakureru/core/theme/app_theme.dart';
 import 'package:kakureru/core/utils/avatar_initial.dart';
 import 'package:kakureru/features/pressure/model/pressure_sensor_availability.dart';
@@ -42,7 +42,7 @@ class RoomWaitingPage extends HookConsumerWidget {
     final demonActionUid = useState<String?>(null);
     final demonActionError = useState<Object?>(null);
     final demonActionGuard = useMemoized(SingleFlightAction.new);
-    final myUid = FirebaseAuth.instance.currentUser?.uid;
+    final myUid = ref.watch(myUidProvider);
     final roomRepo = ref.read(roomRepositoryProvider);
 
     Future<void> runDemonAction(
@@ -91,7 +91,9 @@ class RoomWaitingPage extends HookConsumerWidget {
           Navigator.of(
             context,
           ).pushReplacement(
-            MaterialPageRoute(builder: (_) => GamePage(roomId: roomId)),
+            MaterialPageRoute<void>(
+              builder: (_) => GamePage(roomId: roomId),
+            ),
           );
         });
         return null;
@@ -205,7 +207,7 @@ class RoomWaitingPage extends HookConsumerWidget {
                         Navigator.of(
                           context,
                         ).push(
-                          MaterialPageRoute(
+                          MaterialPageRoute<void>(
                             builder: (_) => RoomSettingPage(roomId: roomId),
                           ),
                         ),

--- a/lib/features/room/view/room_waiting_page.dart
+++ b/lib/features/room/view/room_waiting_page.dart
@@ -91,9 +91,7 @@ class RoomWaitingPage extends HookConsumerWidget {
           Navigator.of(
             context,
           ).pushReplacement(
-            MaterialPageRoute<void>(
-              builder: (_) => GamePage(roomId: roomId),
-            ),
+            MaterialPageRoute(builder: (_) => GamePage(roomId: roomId)),
           );
         });
         return null;
@@ -210,7 +208,7 @@ class RoomWaitingPage extends HookConsumerWidget {
                         Navigator.of(
                           context,
                         ).push(
-                          MaterialPageRoute<void>(
+                          MaterialPageRoute(
                             builder: (_) => RoomSettingPage(roomId: roomId),
                           ),
                         ),

--- a/lib/features/wifi/repository/wifi_scan_repository.dart
+++ b/lib/features/wifi/repository/wifi_scan_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_database/firebase_database.dart';
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:kakureru/features/wifi/repository/proximity_calculator.dart';
 import 'package:wifi_scan/wifi_scan.dart';
 
@@ -34,16 +35,22 @@ class WifiScanRepository {
   void startScanning(String roomId) {
     stopScanning();
 
-    _resultsSub = WiFiScan.instance.onScannedResultsAvailable.listen((results) {
+    _resultsSub = WiFiScan.instance.onScannedResultsAvailable.listen((
+      results,
+    ) async {
       final bssidRssi = <String, int>{};
       for (final ap in results) {
         bssidRssi[ap.bssid] = ap.level;
       }
       final topBssidRssi = selectTopAccessPoints(bssidRssi, count: _maxApCount);
-      _db.ref('rooms/$roomId/locations/$_uid/wifiScan').set({
-        'bssidRssi': topBssidRssi,
-        'scannedAt': ServerValue.timestamp,
-      });
+      try {
+        await _db.ref('rooms/$roomId/locations/$_uid/wifiScan').set({
+          'bssidRssi': topBssidRssi,
+          'scannedAt': ServerValue.timestamp,
+        });
+      } on Object catch (e) {
+        debugPrint('[WifiScanRepository] wifiScanの書き込みに失敗: $e');
+      }
     });
 
     _triggerScan();

--- a/lib/features/wifi/repository/wifi_scan_repository.dart
+++ b/lib/features/wifi/repository/wifi_scan_repository.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_database/firebase_database.dart';
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:kakureru/core/utils/rtdb_write.dart';
 import 'package:kakureru/features/wifi/repository/proximity_calculator.dart';
 import 'package:wifi_scan/wifi_scan.dart';
 
@@ -43,14 +43,14 @@ class WifiScanRepository {
         bssidRssi[ap.bssid] = ap.level;
       }
       final topBssidRssi = selectTopAccessPoints(bssidRssi, count: _maxApCount);
-      try {
-        await _db.ref('rooms/$roomId/locations/$_uid/wifiScan').set({
+      await writeOrLogFailure(
+        () => _db.ref('rooms/$roomId/locations/$_uid/wifiScan').set({
           'bssidRssi': topBssidRssi,
           'scannedAt': ServerValue.timestamp,
-        });
-      } on Object catch (e) {
-        debugPrint('[WifiScanRepository] wifiScanの書き込みに失敗: $e');
-      }
+        }),
+        tag: 'WifiScanRepository',
+        field: 'wifiScan',
+      );
     });
 
     _triggerScan();

--- a/test/core/utils/rtdb_write_test.dart
+++ b/test/core/utils/rtdb_write_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kakureru/core/utils/rtdb_write.dart';
+
+void main() {
+  group('writeOrLogFailure', () {
+    test('書き込みが失敗したら、例外を投げ返さずタグ付きでログに残す', () async {
+      final logs = <String>[];
+
+      await expectLater(
+        writeOrLogFailure(
+          () async => throw Exception('permission denied を模擬'),
+          tag: 'WifiScanRepository',
+          field: 'wifiScan',
+          log: logs.add,
+        ),
+        completes,
+      );
+
+      expect(logs, hasLength(1));
+      expect(logs.single, contains('[WifiScanRepository]'));
+      expect(logs.single, contains('wifiScanの書き込みに失敗'));
+      expect(logs.single, contains('permission denied を模擬'));
+    });
+
+    test('書き込みが成功したらログを出さない', () async {
+      final logs = <String>[];
+
+      await writeOrLogFailure(
+        () async {},
+        tag: 'PressureRepository',
+        field: 'pressure',
+        log: logs.add,
+      );
+
+      expect(logs, isEmpty);
+    });
+
+    test('書き込みの完了を待ち合わせる(投げっぱなしにしない)', () async {
+      // awaitしていなければ、writeOrLogFailureが返った時点では
+      // まだ完了していない(=失敗も検知できない)ことになる。
+      var completed = false;
+
+      await writeOrLogFailure(
+        () async {
+          await Future<void>.delayed(Duration.zero);
+          completed = true;
+        },
+        tag: 'PressureRepository',
+        field: 'pressure',
+        log: (_) {},
+      );
+
+      expect(completed, isTrue);
+    });
+  });
+}

--- a/test/features/location/repository/location_task_handler_test.dart
+++ b/test/features/location/repository/location_task_handler_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:kakureru/features/location/repository/location_task_handler.dart';
+
+/// 位置取得の成功を模擬するための値。中身は使われないので固定でよい。
+Position _somePosition() => Position(
+  latitude: 35.681236,
+  longitude: 139.767125,
+  timestamp: DateTime.utc(2026),
+  accuracy: 5,
+  altitude: 12.5,
+  altitudeAccuracy: 1,
+  heading: 0,
+  headingAccuracy: 1,
+  speed: 0,
+  speedAccuracy: 1,
+);
+
+void main() {
+  group('LocationTaskHandler.sendCurrentPosition', () {
+    test('連続で失敗するたびに、ログの連続失敗回数が1→2→3と増える', () async {
+      final logs = <String>[];
+      final handler = LocationTaskHandler(
+        getCurrentPosition: () async => throw Exception('GPSの失敗を模擬'),
+        log: logs.add,
+      );
+
+      await handler.sendCurrentPosition();
+      await handler.sendCurrentPosition();
+      await handler.sendCurrentPosition();
+
+      expect(logs, hasLength(3));
+      expect(logs[0], contains('1回連続'));
+      expect(logs[1], contains('2回連続'));
+      expect(logs[2], contains('3回連続'));
+      // 失敗の内容も追えるよう、例外の文字列がログに含まれていること。
+      expect(logs.last, contains('GPSの失敗を模擬'));
+    });
+
+    test('失敗は例外として呼び出し側へ投げ返さない(次の周期で再試行するため)', () async {
+      final handler = LocationTaskHandler(
+        getCurrentPosition: () async => throw Exception('GPSの失敗を模擬'),
+        log: (_) {},
+      );
+
+      await expectLater(handler.sendCurrentPosition(), completes);
+    });
+
+    test('取得に成功したら連続失敗回数は0に戻り、その後の失敗は再び1回目から数える', () async {
+      final logs = <String>[];
+      var shouldFail = true;
+      final handler = LocationTaskHandler(
+        getCurrentPosition: () async {
+          if (shouldFail) throw Exception('GPSの失敗を模擬');
+          return _somePosition();
+        },
+        log: logs.add,
+      );
+
+      await handler.sendCurrentPosition();
+      await handler.sendCurrentPosition();
+      expect(logs.last, contains('2回連続'));
+
+      shouldFail = false;
+      await handler.sendCurrentPosition();
+      // 成功時はログを出さない(2件のまま)。
+      expect(logs, hasLength(2));
+
+      shouldFail = true;
+      await handler.sendCurrentPosition();
+      expect(logs, hasLength(3));
+      expect(logs.last, contains('1回連続'));
+    });
+  });
+}

--- a/test/features/room/view/room_setting_page_test.dart
+++ b/test/features/room/view/room_setting_page_test.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/providers/firebase_providers.dart';
+import 'package:kakureru/features/room/model/room.dart';
+import 'package:kakureru/features/room/model/room_setting.dart';
+import 'package:kakureru/features/room/model/room_user.dart';
+import 'package:kakureru/features/room/view/room_setting_page.dart';
+import 'package:kakureru/features/room/view_model/room_view_model.dart';
+
+const _roomId = 'room1';
+
+Room _room() => const Room(
+  id: _roomId,
+  roomCode: '1234',
+  hostUserId: 'host',
+  status: RoomStatus.waiting,
+  createdAt: 0,
+  setting: RoomSetting(),
+  users: [RoomUser(id: 'host', displayName: 'ホスト', isHost: true)],
+);
+
+/// ホストとして設定画面を開き、エリア描画モードに入るまで済ませる。
+Future<void> _openInDrawingMode(WidgetTester tester) async {
+  // 既定の800x600だと「エリアを描く」ボタンが画面外に出てタップできない。
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final controller = StreamController<Room>.broadcast();
+  addTearDown(controller.close);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        myUidProvider.overrideWithValue('host'),
+        roomStreamProvider(_roomId).overrideWith((ref) => controller.stream),
+      ],
+      child: const MaterialApp(home: RoomSettingPage(roomId: _roomId)),
+    ),
+  );
+  await tester.pump();
+  controller.add(_room());
+  await tester.pump();
+
+  await tester.tap(find.text('エリアを描く'));
+  await tester.pump();
+}
+
+/// 地図の上で、[from] から [to] へドラッグしたことにする(座標は地図ローカル)。
+///
+/// `tester.drag` は使えない。flutter_map は `InteractiveFlag.none` でも
+/// ScaleGestureRecognizer を必ず登録し、それがジェスチャーアリーナの
+/// team captain になるため、地図を包む親の GestureDetector の pan は
+/// アリーナで負けて onPanStart が一度も呼ばれない(実測)。ここでは
+/// アリーナを介さず、地図を包む GestureDetector のコールバックを直接呼んで
+/// 「ドラッグが認識された後」の画面の挙動だけを検証する。
+Future<void> _dragOnMap(WidgetTester tester, Offset from, Offset to) async {
+  final detector = tester.widget<GestureDetector>(
+    find.ancestor(
+      of: find.byType(FlutterMap),
+      matching: find.byType(GestureDetector),
+    ),
+  );
+  detector.onPanStart!(DragStartDetails(localPosition: from));
+  detector.onPanUpdate!(
+    DragUpdateDetails(globalPosition: to, localPosition: to),
+  );
+  detector.onPanEnd!(DragEndDetails());
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('サイズが範囲外のドラッグでは、仮矩形を赤枠のまま残す', (tester) async {
+    await _openInDrawingMode(tester);
+
+    // 2px=数mのドラッグはエリアのサイズ下限(対角線10m)に届かず弾かれる。
+    await _dragOnMap(tester, const Offset(400, 160), const Offset(402, 162));
+
+    expect(find.textContaining('エリアが小さすぎます'), findsOneWidget);
+
+    // 弾かれた仮矩形は消さず、赤枠にしてエラーと視覚的に結びつける。
+    final layer = tester.widget<PolygonLayer>(find.byType(PolygonLayer));
+    expect(layer.polygons, hasLength(1));
+    expect(layer.polygons.single.borderColor, Colors.red);
+
+    // 弾かれた矩形はエリアとして採用しない(未設定のまま)。
+    expect(find.textContaining('未設定です'), findsOneWidget);
+  });
+
+  testWidgets('サイズが範囲内のドラッグでは、エリアを確定して仮矩形を消す', (tester) async {
+    await _openInDrawingMode(tester);
+
+    // 100px=概ね200mなのでサイズは範囲内。
+    await _dragOnMap(tester, const Offset(350, 110), const Offset(450, 210));
+
+    expect(find.textContaining('エリアが小さすぎます'), findsNothing);
+    expect(find.textContaining('エリアが大きすぎます'), findsNothing);
+    expect(find.textContaining('未設定です'), findsNothing);
+
+    // 確定したエリア(青枠)だけが残り、仮矩形(赤/橙)は消えている。
+    final layer = tester.widget<PolygonLayer>(find.byType(PolygonLayer));
+    expect(layer.polygons, hasLength(1));
+    expect(layer.polygons.single.borderColor, Colors.blue);
+  });
+
+  testWidgets('弾かれた後に新しいドラッグを始めると、赤枠とエラーは消える', (tester) async {
+    await _openInDrawingMode(tester);
+
+    await _dragOnMap(tester, const Offset(400, 160), const Offset(402, 162));
+    expect(find.textContaining('エリアが小さすぎます'), findsOneWidget);
+
+    final detector = tester.widget<GestureDetector>(
+      find.ancestor(
+        of: find.byType(FlutterMap),
+        matching: find.byType(GestureDetector),
+      ),
+    );
+    detector.onPanStart!(
+      DragStartDetails(localPosition: const Offset(100, 60)),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('エリアが小さすぎます'), findsNothing);
+  });
+}

--- a/test/features/room/view/room_waiting_page_test.dart
+++ b/test/features/room/view/room_waiting_page_test.dart
@@ -1,0 +1,333 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kakureru/core/providers/firebase_providers.dart';
+import 'package:kakureru/features/pressure/model/pressure_sensor_availability.dart';
+import 'package:kakureru/features/pressure/view_model/pressure_view_model.dart';
+import 'package:kakureru/features/room/model/room.dart';
+import 'package:kakureru/features/room/model/room_setting.dart';
+import 'package:kakureru/features/room/model/room_user.dart';
+import 'package:kakureru/features/room/repository/room_repository.dart';
+import 'package:kakureru/features/room/view/room_waiting_page.dart';
+import 'package:kakureru/features/room/view_model/room_view_model.dart';
+
+const _roomId = 'room1';
+const _myUid = 'host';
+
+/// RTDBを叩かずに、鬼指名の完了タイミングだけをテストから制御する
+/// RoomRepositoryの差し替え。
+///
+/// `RoomRepository`のFirebaseハンドルは遅延初期化なので、このサブクラスが
+/// 暗黙の`super()`を通っても`.instance`は解決されない(Firebase未初期化でも
+/// インスタンス化できる)。
+class _FakeRoomRepository extends RoomRepository {
+  /// 直近の`nominateDemon`/`cancelDemonNomination`の完了を制御するCompleter。
+  Completer<void>? pendingAction;
+  final List<String> nominatedUids = [];
+  int cancelCalls = 0;
+  int leaveRoomCalls = 0;
+
+  @override
+  Future<void> nominateDemon(String roomId, String uid) {
+    nominatedUids.add(uid);
+    final completer = Completer<void>();
+    pendingAction = completer;
+    return completer.future;
+  }
+
+  @override
+  Future<void> cancelDemonNomination(String roomId) {
+    cancelCalls++;
+    final completer = Completer<void>();
+    pendingAction = completer;
+    return completer.future;
+  }
+
+  @override
+  Future<void> acceptDemonNomination(String roomId, String uid) async {}
+
+  // 待機画面はdispose時に必ずleaveRoomを呼ぶので、ここで吸収する。
+  @override
+  Future<void> leaveRoom(String roomId) async {
+    leaveRoomCalls++;
+  }
+}
+
+/// センサーとRTDBを触らずに、キャリブレーション中の状態だけを再現する
+/// PressureViewModelの差し替え。
+class _FakePressureViewModel extends PressureViewModel {
+  _FakePressureViewModel({this.initialState = const PressureState()});
+
+  final PressureState initialState;
+
+  /// キャリブレーションの完了を制御するCompleter(呼ばれるまでnull)。
+  Completer<void>? pendingCalibration;
+
+  @override
+  PressureState build() => initialState;
+
+  // 本物はセンサーの有無を実機に問い合わせるので何もしない。
+  @override
+  Future<void> init(String roomId) async {}
+
+  @override
+  Future<void> calibrateAsHost(String roomId) async {
+    final completer = Completer<void>();
+    pendingCalibration = completer;
+    state = state.copyWith(isCalibrating: true);
+    try {
+      await completer.future;
+    } finally {
+      state = state.copyWith(isCalibrating: false);
+    }
+  }
+}
+
+/// 気圧を取得済み・キャリブレーション未実施のホスト1人だけのルーム。
+Room _room({String? pendingDemonUid, int createdAt = 0}) => Room(
+  id: _roomId,
+  roomCode: '1234',
+  hostUserId: _myUid,
+  status: RoomStatus.waiting,
+  createdAt: createdAt,
+  pendingDemonUid: pendingDemonUid,
+  setting: const RoomSetting(),
+  users: const [
+    RoomUser(
+      id: _myUid,
+      displayName: 'ホスト',
+      isHost: true,
+      pressureSensorAvailable: true,
+    ),
+  ],
+);
+
+/// 待機画面を開いて、最初のルームのスナップショットを流すところまで行う。
+Future<StreamController<Room>> _pumpWaitingPage(
+  WidgetTester tester, {
+  required _FakeRoomRepository roomRepo,
+  required _FakePressureViewModel pressureViewModel,
+  Room? initialRoom,
+}) async {
+  // 既定の800x600では下部のボタンが画面外に出てタップできない。
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final controller = StreamController<Room>.broadcast();
+  addTearDown(controller.close);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        myUidProvider.overrideWithValue(_myUid),
+        roomRepositoryProvider.overrideWithValue(roomRepo),
+        pressureViewModelProvider.overrideWith(() => pressureViewModel),
+        roomStreamProvider(_roomId).overrideWith((ref) => controller.stream),
+      ],
+      child: const MaterialApp(home: RoomWaitingPage(roomId: _roomId)),
+    ),
+  );
+  await tester.pump();
+  controller.add(initialRoom ?? _room());
+  await tester.pump();
+  return controller;
+}
+
+ActionChip _chipWithText(WidgetTester tester, String label) =>
+    tester.widget<ActionChip>(find.widgetWithText(ActionChip, label));
+
+void main() {
+  group('鬼指名(「鬼にする」「取り消す」)', () {
+    testWidgets('送信中はチップがスピナーになり、押せなくなる', (tester) async {
+      final roomRepo = _FakeRoomRepository();
+      await _pumpWaitingPage(
+        tester,
+        roomRepo: roomRepo,
+        pressureViewModel: _FakePressureViewModel(),
+      );
+
+      expect(_chipWithText(tester, '鬼にする').onPressed, isNotNull);
+
+      await tester.tap(find.widgetWithText(ActionChip, '鬼にする'));
+      await tester.pump();
+
+      expect(roomRepo.nominatedUids, [_myUid]);
+      // ラベルがスピナーに差し替わるのでテキストは消える。
+      expect(find.widgetWithText(ActionChip, '鬼にする'), findsNothing);
+      final chip = tester.widget<ActionChip>(find.byType(ActionChip));
+      expect(chip.label, isA<SizedBox>());
+      expect(
+        find.descendant(
+          of: find.byType(ActionChip),
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsOneWidget,
+      );
+      expect(chip.onPressed, isNull);
+    });
+
+    testWidgets('送信が失敗したらエラーを表示し、チップは押せる状態に戻る', (tester) async {
+      final roomRepo = _FakeRoomRepository();
+      await _pumpWaitingPage(
+        tester,
+        roomRepo: roomRepo,
+        pressureViewModel: _FakePressureViewModel(),
+      );
+
+      await tester.tap(find.widgetWithText(ActionChip, '鬼にする'));
+      await tester.pump();
+
+      roomRepo.pendingAction!.completeError(Exception('指名の失敗を模擬'));
+      await tester.pump();
+
+      expect(find.textContaining('指名の失敗を模擬'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(ActionChip),
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsNothing,
+      );
+      expect(_chipWithText(tester, '鬼にする').onPressed, isNotNull);
+    });
+
+    testWidgets('送信中の連打は無視され、リクエストは1回しか飛ばない', (tester) async {
+      final roomRepo = _FakeRoomRepository();
+      await _pumpWaitingPage(
+        tester,
+        roomRepo: roomRepo,
+        pressureViewModel: _FakePressureViewModel(),
+      );
+
+      await tester.tap(find.widgetWithText(ActionChip, '鬼にする'));
+      await tester.pump();
+      // 無効化されたチップを押しても何も起きない(warnIfMissedは不要)。
+      await tester.tap(find.byType(ActionChip));
+      await tester.pump();
+
+      expect(roomRepo.nominatedUids, hasLength(1));
+    });
+
+    testWidgets('「取り消す」も送信中はスピナーになり、押せなくなる', (tester) async {
+      final roomRepo = _FakeRoomRepository();
+      await _pumpWaitingPage(
+        tester,
+        roomRepo: roomRepo,
+        pressureViewModel: _FakePressureViewModel(),
+        initialRoom: _room(pendingDemonUid: _myUid),
+      );
+
+      expect(_chipWithText(tester, '取り消す').onPressed, isNotNull);
+
+      await tester.tap(find.widgetWithText(ActionChip, '取り消す'));
+      await tester.pump();
+
+      expect(roomRepo.cancelCalls, 1);
+      expect(find.widgetWithText(ActionChip, '取り消す'), findsNothing);
+      expect(
+        find.descendant(
+          of: find.byType(ActionChip),
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsOneWidget,
+      );
+      expect(tester.widget<ActionChip>(find.byType(ActionChip)).onPressed,
+          isNull);
+    });
+  });
+
+  testWidgets('画面が破棄されたらルームから退出する', (tester) async {
+    // 破棄時のleaveRoomは、以前はdispose中にref.readしていたため
+    // StateErrorで呼ばれないままになっていた(build時に取得した
+    // roomRepoを使う形に修正済み)。その再発防止。
+    final roomRepo = _FakeRoomRepository();
+    await _pumpWaitingPage(
+      tester,
+      roomRepo: roomRepo,
+      pressureViewModel: _FakePressureViewModel(),
+    );
+    expect(roomRepo.leaveRoomCalls, 0);
+
+    // 別の画面に差し替えて待機画面をunmountさせる。
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await tester.pump();
+
+    expect(roomRepo.leaveRoomCalls, 1);
+  });
+
+  group('キャリブレーションボタン', () {
+    testWidgets('押すとスピナーとキャリブレーション中の表示に変わり、押せなくなる', (tester) async {
+      final pressureViewModel = _FakePressureViewModel(
+        initialState: const PressureState(
+          sensorAvailability: PressureSensorAvailability.available,
+          myPressureHPa: 1013,
+        ),
+      );
+      await _pumpWaitingPage(
+        tester,
+        roomRepo: _FakeRoomRepository(),
+        pressureViewModel: pressureViewModel,
+      );
+
+      final button = find.widgetWithText(
+        FilledButton,
+        'キャリブレーションする(未実施)',
+      );
+      expect(button, findsOneWidget);
+      expect(tester.widget<FilledButton>(button).onPressed, isNotNull);
+
+      await tester.tap(button);
+      await tester.pump();
+
+      expect(find.text('キャリブレーション中...'), findsOneWidget);
+      final calibratingButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'キャリブレーション中...'),
+      );
+      expect(
+        find.descendant(
+          of: find.widgetWithText(FilledButton, 'キャリブレーション中...'),
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsOneWidget,
+      );
+      expect(calibratingButton.onPressed, isNull);
+
+      pressureViewModel.pendingCalibration!.complete();
+      await tester.pump();
+
+      expect(find.text('キャリブレーション中...'), findsNothing);
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.widgetWithText(FilledButton, 'キャリブレーションする(未実施)'),
+            )
+            .onPressed,
+        isNotNull,
+      );
+    });
+
+    testWidgets('気圧をまだ取得できていない間は押せず、取得中と伝える', (tester) async {
+      await _pumpWaitingPage(
+        tester,
+        roomRepo: _FakeRoomRepository(),
+        pressureViewModel: _FakePressureViewModel(
+          initialState: const PressureState(
+            sensorAvailability: PressureSensorAvailability.available,
+          ),
+        ),
+      );
+
+      expect(find.text('気圧を取得中...'), findsOneWidget);
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.widgetWithText(FilledButton, 'キャリブレーションする(未実施)'),
+            )
+            .onPressed,
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/room/view/room_waiting_page_test.dart
+++ b/test/features/room/view/room_waiting_page_test.dart
@@ -233,8 +233,10 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(tester.widget<ActionChip>(find.byType(ActionChip)).onPressed,
-          isNull);
+      expect(
+        tester.widget<ActionChip>(find.byType(ActionChip)).onPressed,
+        isNull,
+      );
     });
   });
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,8 +1,39 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:kakureru/features/room/view/room_home_page.dart';
+import 'package:kakureru/features/room/view_model/room_view_model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+/// createRoom/joinRoomの完了タイミングをテストから制御するための
+/// RoomViewModelの差し替え。本物はFirebase/device_info_plusを叩くため
+/// widgetテストでは呼べず、Completerで代わりに結果を注入する。
+class _ControllableRoomViewModel extends RoomViewModel {
+  Completer<String?>? createCompleter;
+  Completer<String?>? joinCompleter;
+  var createCallCount = 0;
+  var joinCallCount = 0;
+
+  @override
+  Future<void> createRoom(String displayName) async {
+    createCallCount++;
+    final completer = Completer<String?>();
+    createCompleter = completer;
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() => completer.future);
+  }
+
+  @override
+  Future<void> joinRoom(String code, String displayName) async {
+    joinCallCount++;
+    final completer = Completer<String?>();
+    joinCompleter = completer;
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() => completer.future);
+  }
+}
 
 void main() {
   setUp(() {
@@ -19,7 +50,7 @@ void main() {
     expect(find.text('ルームに参加'), findsOneWidget);
   });
 
-  testWidgets('初期表示では名前が空でもエラーは出ずボタンも押せる', (tester) async {
+  testWidgets('初期表示では名前が空でエラーは出ず、ボタンは無効化されている', (tester) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: RoomHomePage())),
     );
@@ -33,48 +64,129 @@ void main() {
     final joinButton = tester.widget<OutlinedButton>(
       find.widgetWithText(OutlinedButton, 'ルームに参加'),
     );
-    expect(createButton.onPressed, isNotNull);
-    expect(joinButton.onPressed, isNotNull);
+    expect(createButton.onPressed, isNull);
+    expect(joinButton.onPressed, isNull);
   });
 
-  testWidgets('名前が空のまま「ルームを作る」を押すとエラーが表示される', (tester) async {
+  testWidgets('名前を入力すればボタンが有効化される', (tester) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: RoomHomePage())),
     );
     await tester.pump();
 
-    await tester.tap(find.widgetWithText(FilledButton, 'ルームを作る'));
+    await tester.enterText(find.byType(TextField).first, 'たろう');
+    await tester.pump();
+
+    final createButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'ルームを作る'),
+    );
+    final joinButton = tester.widget<OutlinedButton>(
+      find.widgetWithText(OutlinedButton, 'ルームに参加'),
+    );
+    expect(createButton.onPressed, isNotNull);
+    expect(joinButton.onPressed, isNotNull);
+  });
+
+  testWidgets('名前を入力してから空に戻すとエラーが表示され、ボタンは無効のまま', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: RoomHomePage())),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField).first, 'たろう');
+    await tester.pump();
+    await tester.enterText(find.byType(TextField).first, '');
     await tester.pump();
 
     expect(find.text('名前を入力してください'), findsOneWidget);
+    final createButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'ルームを作る'),
+    );
+    expect(createButton.onPressed, isNull);
   });
 
-  testWidgets('空白のみの名前で「ルームに参加」を押してもエラーが表示される', (tester) async {
+  testWidgets('空白のみの名前を入力するとエラーが表示される', (tester) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: RoomHomePage())),
     );
     await tester.pump();
 
     await tester.enterText(find.byType(TextField).first, '   ');
-    await tester.tap(find.widgetWithText(OutlinedButton, 'ルームに参加'));
     await tester.pump();
 
     expect(find.text('名前を入力してください'), findsOneWidget);
   });
 
-  testWidgets('エラー表示後に有効な名前を入力するとエラーが消える', (tester) async {
+  testWidgets('「ルームを作る」を押すと送信中はスピナーが出て両ボタンとも無効化される', (
+    tester,
+  ) async {
+    final model = _ControllableRoomViewModel();
+
     await tester.pumpWidget(
-      const ProviderScope(child: MaterialApp(home: RoomHomePage())),
+      ProviderScope(
+        overrides: [
+          roomViewModelProvider.overrideWith(() => model),
+        ],
+        child: const MaterialApp(home: RoomHomePage()),
+      ),
     );
     await tester.pump();
-
-    await tester.tap(find.widgetWithText(FilledButton, 'ルームを作る'));
-    await tester.pump();
-    expect(find.text('名前を入力してください'), findsOneWidget);
 
     await tester.enterText(find.byType(TextField).first, 'たろう');
     await tester.pump();
 
-    expect(find.text('名前を入力してください'), findsNothing);
+    await tester.tap(find.widgetWithText(FilledButton, 'ルームを作る'));
+    await tester.pump();
+
+    expect(model.createCallCount, 1);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('ルームを作る'), findsNothing);
+
+    final createButtonWhileLoading = tester.widget<FilledButton>(
+      find.byType(FilledButton),
+    );
+    final joinButtonWhileLoading = tester.widget<OutlinedButton>(
+      find.byType(OutlinedButton),
+    );
+    expect(createButtonWhileLoading.onPressed, isNull);
+    expect(joinButtonWhileLoading.onPressed, isNull);
+
+    // 失敗させて、スピナーが消えてエラー表示・再操作可能に戻ることを確認する。
+    model.createCompleter!.completeError(Exception('boom'));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('ルームを作る'), findsOneWidget);
+    expect(find.textContaining('boom'), findsOneWidget);
+  });
+
+  testWidgets('「ルームに参加」を押すと送信中はスピナーが出る', (tester) async {
+    final model = _ControllableRoomViewModel();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          roomViewModelProvider.overrideWith(() => model),
+        ],
+        child: const MaterialApp(home: RoomHomePage()),
+      ),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField).first, 'たろう');
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(OutlinedButton, 'ルームに参加'));
+    await tester.pump();
+
+    expect(model.joinCallCount, 1);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('ルームに参加'), findsNothing);
+
+    model.joinCompleter!.completeError(Exception('boom'));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('ルームに参加'), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,8 +13,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _ControllableRoomViewModel extends RoomViewModel {
   Completer<String?>? createCompleter;
   Completer<String?>? joinCompleter;
-  var createCallCount = 0;
-  var joinCallCount = 0;
+  int createCallCount = 0;
+  int joinCallCount = 0;
 
   @override
   Future<void> createRoom(String displayName) async {


### PR DESCRIPTION
## 概要

issue #34「エラーハンドリングとローディング表示が欠けている箇所を修正する」の受け入れ条件7件に対応。

1. `LocationTaskHandler` — `catch(_)` で握りつぶさず、連続失敗回数をカウントして `debugPrint` でログする
2. `WifiScanRepository` / `PressureRepository` の RTDB 書き込み — `set()` を `await` し、失敗時にログを残す
3. `room_setting_page.dart` — プレイエリアのサイズ超過時、ドラッグ中の仮矩形をリセットせず赤枠のまま残し、エラーメッセージと視覚的に結びつける
4. `room_home_page.dart` — 名前が空/不正な間は「ルームを作る」「ルームに参加」ボタン自体を無効化。**「2回押さないと反応しない」不具合の再現条件を解消**
5. `room_waiting_page.dart` — 「鬼にする」「取り消す」に送信中フラグ・エラー表示・ボタン無効化を追加(既存の `isSaving`/`saveError` パターンを踏襲)
6. `room_waiting_page.dart` — キャリブレーションボタンに `isCalibrating` 中のスピナー表示を追加
7. `room_home_page.dart` — 「ルームを作る」「ルームに参加」ボタン押下時にボタン内スピナー表示を追加

## 機械検証の結果

**当初このPRは「`flutter test` / `flutter analyze` を実行できていない」状態で作成されていた**(実行環境に Flutter ツールチェインが無かったため)。ローカルの Flutter 3.44.8 で実行し、以下を確認した。

| 項目 | main のベースライン | このブランチ |
| --- | --- | --- |
| `flutter test` | 198件 全通過 | **216件 全通過**(+18) |
| `flutter analyze` | 296 issues (info 292 + warning 4 + error 0) | 289 issues (info 285 + warning 4 + error 0)。**新規指摘 0件** |
| `dart format`(このPRが触った14ファイル) | — | 差分なし |
| `python3 scripts/verify_safety_net.py` | 27件中1件失敗(既存の壊れたリンク) | 同じ1件のみ。増えていない |

`flutter analyze` の比較は件数ではなく**指摘の集合**(重大度・ファイル・ルール)で行った。`git archive main` で複製した main と両方 `dart analyze` にかけて多重集合の差分を取っている。

### 既存指摘が7件解消される点について

このPRは**新規指摘を1件も増やしていない**が、seam の実装に伴って既存指摘が7件解消されている。件数が動いた理由を追えるよう内訳を示す。

| 件数 | ルール | 経緯 |
| --- | --- | --- |
| 2 | `discarded_futures`(wifi / pressure) | item 2 が「`set()` を await せよ」と要求している当該行そのもの。await すれば定義上消える |
| 1 | `lines_longer_than_80_chars`(location_task_handler) | item 1 で書き換えた行が80文字超だったため、再折り返しが必要 |
| 1 | `discarded_futures`(location_task_handler) | `unawaited()` はこの lint 自身が提示する修正方法 |
| 1 | `sort_constructors_first`(room_repository) | seam B でクラス冒頭を作り直す際、有効な lint に反する順序をあえて維持する理由がない |
| 1 | `public_member_api_docs`(room_repository のコンストラクタ) | 初期化子リストを書き換えた当該メンバーへの doc |
| 1 | `public_member_api_docs`(room_repository のクラス宣言) | **これのみ不可避ではない。** lint 件数を維持するために doc コメントを削るのは本末転倒と判断して残した |

なお main に既存の warning 4件(`inference_failure_on_instance_creation` / `MaterialPageRoute` の型引数)は、当初「ついでに」修正していたが、**レビューでスコープ違反と指摘され差し戻した**。この修正自体は正しい内容なので別の小さなPRとして提出する。

## テスト容易性のために追加した seam(4件)

item 1・2・3・5・6 は「モック基盤がリポジトリに存在しない」ためテストが書けない状態だった。テストを書けるようにするため、**リポジトリに既存の手本があるやり方だけ**を使って seam を4つ追加した。**いずれも本番の振る舞いは変えていない。**

- **Seam A**: `lib/core/providers/firebase_providers.dart`(初回コミットから0バイトの空ファイル)に uid を供給する provider を定義し、`room_waiting_page.dart` / `room_setting_page.dart` の `build()` 直下の `FirebaseAuth.instance` 直参照を置き換えた。**この直参照があると `Firebase.initializeApp()` していないテストで `[core/no-app]` 例外になり、provider 経由でないため `ProviderScope(overrides:)` でも差し替えられなかった。** `main()` が `runApp` 前に `signInAnonymously()` を完了させるので uid は変化せず、キャッシュしても安全。**必要になった2ファイルのみ**に適用している(`game_page.dart` と ViewModel 群は差分最小化のため未変更)。
- **Seam B**: `RoomRepository` の `.instance` 解決を初期化子リストから `late final` へ。**従来は `extends` した瞬間に暗黙の `super()` で `.instance` が走るため fake サブクラスが作れなかった**(`FirebaseDatabase`/`FirebaseAuth` 自体は private コンストラクタなのでテストダブルも渡せない)。既存の `_FakeBleScanRepository extends BleScanRepository` と同じパターンが使えるようになる。解決規則(`引数 ?? .instance`)は不変で、タイミングだけが構築時→初回使用時に移る。
- **Seam C**: `LocationTaskHandler` にコンストラクタ関数注入(位置取得関数・ログ関数)。既存の `ble_permission.dart` / `location_permission.dart` と同一パターン。本番は引数なしで構築するので実物を使う。
- **Seam D**: Wi-Fi と気圧の両リポジトリが重複して持っていた「await して失敗をログに残す」処理を `lib/core/utils/rtdb_write.dart` に切り出し、**2箇所から使用**。ログ文字列は従来と同一。

## テストについて

追加した18件は、**それぞれ本番コードを壊すと落ちることを変異テストで確認済み**(レビュー担当が独立に再実行して確認)。

| item | テストファイル |
| --- | --- |
| 1 | `test/features/location/repository/location_task_handler_test.dart` |
| 2 | `test/core/utils/rtdb_write_test.dart` |
| 3 | `test/features/room/view/room_setting_page_test.dart` |
| 5・6 | `test/features/room/view/room_waiting_page_test.dart` |
| 4・7 | `test/widget_test.dart`(既存を拡充) |

### item 2 の残った制約(手動確認が必要)

item 2 のテストは**切り出した関数のみ**を対象としており、**2つのリポジトリの呼び出し配線はテストされていない**(配線を元に戻してもテストは落ちない)。`WiFiScan.instance` が private コンストラクタ＋setter 無しで差し替え不能、`WiFiAccessPoint` も private コンストラクタのみのため、モックライブラリを入れてもスキャン経路自体を駆動できない(そのため依存追加はしていない)。

**手動確認方法**: RTDB のセキュリティルールを一時的に拒否設定にする(または機内モードにする)状態で Wi-Fi スキャン/気圧送信を動かし、`[WifiScanRepository] wifiScanの書き込みに失敗: ...` / `[PressureRepository] pressureの書き込みに失敗: ...` がログに出ることを確認する。

### item 3 のテスト手法について

`_AreaMap` は `GestureDetector` で `FlutterMap` を包む構造だが、**flutter_map が `ScaleGestureRecognizer` を `if (dragEnabled)` の外側で無条件に登録し `_gestureArenaTeam.captain` に設定するため、`InteractiveFlag.none` にしても子の recognizer が親の pan に勝ち、`tester.drag` では `onPanStart` が発火しない**。そのためテストはページ側の `GestureDetector` のコールバックを直接呼ぶ形にしている(`MapCamera.screenOffsetToLatLng` と `describeGameAreaSizeError`、`PolygonLayer` の描画は実物を通る)。**これは実機でも同じ可能性があり、#38 として切り出した(要実機確認)。**

## 7項目外の修正が1件含まれている(実在するバグ)

`lib/features/room/view/room_waiting_page.dart` の**退出処理が実行されていなかった**のを修正した。

`useEffect` のクリーンアップが `ref.read(roomRepositoryProvider).leaveRoom(roomId)` を呼んでいたが、Riverpod 3 の `ConsumerStatefulElement._assertNotDisposed` はアンマウント後に**デバッグ時限定でなく常に** `Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe.` を投げる。flutter_hooks がそれを捕まえてログに出すだけだったため、**待機画面から戻るたびに退出処理が黙って飛ばされ、`users/{uid}` と `locations/{uid}` が RTDB に残っていた。**

build 時に取得済みの `roomRepo` を使う形に修正(Riverpod のエラーメッセージが推奨する対処そのもの)。この修正なしでは待機画面の widget テスト7件が dispose 時例外で全滅するため、item 5・6 のテストに必須だった。回帰テストも追加している。

## レビュー

実装担当とは別のレビュー担当エージェントが、main との全差分(このPRの元コミットを含む)を独立にレビューした。

- **1巡目: 不合格(84点)** — 既存 warning 4件の修正が計画のスコープ外。新規 lint 指摘2件。`dart format` 逸脱2箇所
- **2巡目: 合格(93点)** — 5観点(要件充足 / スコープ厳守 / 不要コード / テスト / 禁止事項)すべて合格

## 動作確認方法(手動)

- item 1: 実機でGPSをOFFにしたまま数分間フォアグラウンドサービスを動かし、`adb logcat` 等で `[LocationTaskHandler] 位置取得に失敗(N回連続)` が出ることを確認
- item 2: 上記「item 2 の残った制約」を参照
- item 3: ルーム設定画面でプレイエリアを極端に大きく/小さくドラッグし、赤枠のまま矩形が残ることを確認。「描画をやめる」で赤枠が消えることも確認(**#38 のため、そもそもドラッグが効かない可能性がある**)
- item 4: アプリ起動直後、名前が自動入力される前に「ルームを作る」を押しても無効化されていること、自動入力後に有効化されることを確認
- item 5: ホストとして「鬼にする」を押し、スピナーが出て他の行も無効化されること、意図的にオフラインにしてエラー表示も確認
- item 6: 気圧センサーがある端末でキャリブレーションボタンを押し、スピナーと「キャリブレーション中...」に切り替わることを確認
- item 7: 「ルームを作る」を押し、押した側のボタンだけにスピナーが出ることを確認
- 退出処理: 待機画面から戻り、RTDB の `rooms/{roomId}/users/{uid}` が消えることを確認

## follow-up(このPRのスコープ外)

- **#38** — 「エリアを描く」のドラッグが flutter_map のジェスチャーに食われている可能性(要実機確認)。事実なら must 級
- `game_page.dart` の `FirebaseAuth.instance` 直参照は未変更。Seam A の provider に置き換えれば、#35 が「配線のテストが書けない」として残した分も書けるようになる
- `PressureRepository` / `WifiScanRepository` / `LocationRepository` は Seam B と同じ「初期化子リストで `.instance` を即時評価」のままで、fake サブクラスが作れない
- 「鬼をランダムで決める」は今も catch なし＝エラー表示がない(item 5 の対象外なので意図的に未変更)
- `LocationTaskHandler` は連続失敗カウントのリセットを送信の前に置いているため、送信側の例外も「位置取得に失敗(1回連続)」と記録される(文言のずれのみ、検知自体は成立)
- **このリポジトリには CI(`.github/workflows/`)が無い。** 「コンパイルされていないコードがPRになる」事故の根本原因はこれで、`flutter pub get && flutter analyze && flutter test` を回すだけのワークフローがあればPRの時点で止まる

Closes #34